### PR TITLE
chore(github-actions): don't run CI on closed pr to master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI test and build
 on:
   push:
   pull_request:
-    types: [opened, closed]
+    types: [opened]
     branches:
       - main
 


### PR DESCRIPTION
(runs automatically on "push" of pull request commit)