### PR TITLE
Refactor tests

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -86,6 +86,7 @@ defmodule EpochtalkServer.MixProject do
         "ecto.migrate --quiet",
         "seed.banned_address",
         "seed.all",
+        "seed.user test test@test.com password",
         "test"
       ]
     ]

--- a/test/epochtalk_server_web/channels/user_channel_test.exs
+++ b/test/epochtalk_server_web/channels/user_channel_test.exs
@@ -138,7 +138,7 @@ defmodule EpochtalkServerWeb.UserChannelTest do
   end
 
   defp create_authed_socket() do
-    {:ok, user} = User.create(%{username: "test", email: "test@test.com", password: "password"})
+    {:ok, user} = User.create(%{username: "userchanneltest", email: "userchanneltest@test.com", password: "password"})
     conn = Phoenix.ConnTest.build_conn()
     {:ok, user, token, _conn} = Session.create(user, false, conn)
 

--- a/test/epochtalk_server_web/channels/user_channel_test.exs
+++ b/test/epochtalk_server_web/channels/user_channel_test.exs
@@ -138,7 +138,13 @@ defmodule EpochtalkServerWeb.UserChannelTest do
   end
 
   defp create_authed_socket() do
-    {:ok, user} = User.create(%{username: "userchanneltest", email: "userchanneltest@test.com", password: "password"})
+    {:ok, user} =
+      User.create(%{
+        username: "userchanneltest",
+        email: "userchanneltest@test.com",
+        password: "password"
+      })
+
     conn = Phoenix.ConnTest.build_conn()
     {:ok, user, token, _conn} = Session.create(user, false, conn)
 

--- a/test/epochtalk_server_web/channels/user_socket_test.exs
+++ b/test/epochtalk_server_web/channels/user_socket_test.exs
@@ -16,7 +16,13 @@ defmodule EpochtalkServerWeb.UserSocketTest do
     end
 
     test "returns authenticated socket for a valid JWT with backing user" do
-      {:ok, user} = User.create(%{username: "usersockettest", email: "usersockettest@test.com", password: "password"})
+      {:ok, user} =
+        User.create(%{
+          username: "usersockettest",
+          email: "usersockettest@test.com",
+          password: "password"
+        })
+
       conn = Phoenix.ConnTest.build_conn()
       {:ok, user, token, _conn} = Session.create(user, false, conn)
       user_id = user.id

--- a/test/epochtalk_server_web/channels/user_socket_test.exs
+++ b/test/epochtalk_server_web/channels/user_socket_test.exs
@@ -16,7 +16,7 @@ defmodule EpochtalkServerWeb.UserSocketTest do
     end
 
     test "returns authenticated socket for a valid JWT with backing user" do
-      {:ok, user} = User.create(%{username: "test", email: "test@test.com", password: "password"})
+      {:ok, user} = User.create(%{username: "usersockettest", email: "usersockettest@test.com", password: "password"})
       conn = Phoenix.ConnTest.build_conn()
       {:ok, user, token, _conn} = Session.create(user, false, conn)
       user_id = user.id

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -17,16 +17,16 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     password: "password"
   }
 
-  @confirm_invalid_username %{username: "blank", token: 1}
+  @confirm_invalid_username %{username: "invalidusernametest", token: 1}
   @confirm_invalid_token %{username: @create_username, token: 1}
 
-  @invalid_username_attrs %{username: "", email: "invalidtest@test.com", password: "password"}
-  @invalid_password_attrs %{username: "invalid", email: "invalidtest@test.com", password: ""}
+  @invalid_username_attrs %{username: "", email: "invalidusernametest@test.com", password: "password"}
+  @invalid_password_attrs %{username: "invalidpasswordtest", email: "invalidpasswordtest@test.com", password: ""}
 
   @login_create_attrs %{username: "logintest", email: "logintest@test.com", password: "password"}
   @login_attrs %{username: "logintest", password: "password"}
   @invalid_login_password_attrs %{username: "logintest", password: "1"}
-  @invalid_login_username_attrs %{username: "test", password: "password"}
+  @invalid_login_username_attrs %{username: "invalidlogintest", password: "password"}
 
   describe "username/2" do
     setup [:create_user]

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -121,26 +121,26 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   describe "confirm/2" do
     setup [:create_user]
 
-    test "confirms user using token", %{conn: conn} do
-      {:ok, user} = User.by_username(@create_attrs.username)
-
+    test "confirms user using token", %{conn: conn, user: user} do
+      # confirm user
       User
       |> Repo.get(user.id)
       |> change(%{confirmation_token: :crypto.strong_rand_bytes(20) |> Base.encode64()})
       |> Repo.update()
 
-      {:ok, user} = User.by_username(@create_attrs.username)
+      # refresh user data
+      {:ok, confirmed_user} = User.by_username(@create_attrs.username)
 
       conn =
         post(
           conn,
           Routes.user_path(conn, :confirm, %{
-            username: user.username,
-            token: user.confirmation_token
+            username: confirmed_user.username,
+            token: confirmed_user.confirmation_token
           })
         )
 
-      assert user.id == json_response(conn, 200)["id"]
+      assert confirmed_user.id == json_response(conn, 200)["id"]
     end
 
     test "errors with 400 when user not found", %{conn: conn} do

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -186,15 +186,13 @@ defmodule EpochtalkServerWeb.UserControllerTest do
                json_response(conn, 400)
     end
 
-    test "errors with 403 if user is missing passhash", %{conn: conn} do
-      {:ok, user} = User.by_username(@login_attrs.username)
-
+    test "errors with 403 if user is missing passhash", %{conn: conn, user: user, user_attrs: user_attrs} do
       User
       |> Repo.get(user.id)
       |> change(%{passhash: nil})
       |> Repo.update()
 
-      conn = post(conn, Routes.user_path(conn, :login, @login_attrs))
+      conn = post(conn, Routes.user_path(conn, :login, user_attrs))
 
       assert %{
                "error" => "Forbidden",

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -20,7 +20,6 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   @blank_username_attrs %{username: "", email: "blankusernametest@test.com", password: "password"}
   @blank_password_attrs %{username: "blankpasswordtest", email: "blankpasswordtest@test.com", password: ""}
 
-  @login_create_attrs %{username: "logintest", email: "logintest@test.com", password: "password"}
   @invalid_password_login_attrs %{username: "logintest", password: "1"}
   @invalid_username_login_attrs %{username: "invalidlogintest", password: "password"}
 
@@ -158,8 +157,6 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   end
 
   describe "login/2" do
-    setup [:create_login_user]
-
     test "logs in a user", %{conn: conn, user: user, user_attrs: user_attrs} do
       conn = post(conn, Routes.user_path(conn, :login, user_attrs))
       assert user.id == json_response(conn, 200)["id"]
@@ -250,10 +247,5 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   defp ban_user(%{user: user}) do
     {:ok, banned_user} = Ban.ban(user, NaiveDateTime.utc_now())
     {:ok, banned_user: banned_user}
-  end
-
-  defp create_login_user(_) do
-    {:ok, user} = User.create(@login_create_attrs)
-    {:ok, user: user, user_attrs: @login_create_attrs}
   end
 end

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -75,9 +75,8 @@ defmodule EpochtalkServerWeb.UserControllerTest do
       assert user.id == json_response(conn, 200)["id"]
     end
 
-    test "errors with 400 when email is already taken", %{conn: conn} do
-      User.create(@register_attrs)
-      conn = post(conn, Routes.user_path(conn, :register, @register_attrs))
+    test "errors with 400 when email is already taken", %{conn: conn, user_attrs: existing_user_attrs} do
+      conn = post(conn, Routes.user_path(conn, :register, existing_user_attrs))
 
       assert %{"error" => "Bad Request", "message" => "Email has already been taken"} =
                json_response(conn, 400)

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -161,9 +161,8 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   describe "login/2" do
     setup [:create_login_user]
 
-    test "logs in a user", %{conn: conn} do
-      conn = post(conn, Routes.user_path(conn, :login, @login_attrs))
-      {:ok, user} = User.by_username(@login_attrs.username)
+    test "logs in a user", %{conn: conn, user: user, user_attrs: user_attrs} do
+      conn = post(conn, Routes.user_path(conn, :login, user_attrs))
       assert user.id == json_response(conn, 200)["id"]
     end
 

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -17,8 +17,8 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   @confirm_invalid_username %{username: "invalidusernametest", token: 1}
   @confirm_invalid_token %{username: @create_username, token: 1}
 
-  @invalid_username_attrs %{username: "", email: "invalidusernametest@test.com", password: "password"}
-  @invalid_password_attrs %{username: "invalidpasswordtest", email: "invalidpasswordtest@test.com", password: ""}
+  @blank_username_attrs %{username: "", email: "blankusernametest@test.com", password: "password"}
+  @blank_password_attrs %{username: "blankpasswordtest", email: "blankpasswordtest@test.com", password: ""}
 
   @login_create_attrs %{username: "logintest", email: "logintest@test.com", password: "password"}
   @login_attrs %{username: "logintest", password: "password"}
@@ -104,14 +104,14 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     end
 
     test "errors with 400 when username is missing", %{conn: conn} do
-      conn = post(conn, Routes.user_path(conn, :register, @invalid_username_attrs))
+      conn = post(conn, Routes.user_path(conn, :register, @blank_username_attrs))
 
       assert %{"error" => "Bad Request", "message" => "Username can't be blank"} =
                json_response(conn, 400)
     end
 
     test "errors with 400 when password is missing", %{conn: conn} do
-      conn = post(conn, Routes.user_path(conn, :register, @invalid_password_attrs))
+      conn = post(conn, Routes.user_path(conn, :register, @blank_password_attrs))
 
       assert %{"error" => "Bad Request", "message" => "Password can't be blank"} =
                json_response(conn, 400)

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -64,13 +64,7 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   end
 
   describe "unban/1" do
-    setup [:create_user]
-
-    # Setup by banning a user first using ban/2
-    setup %{user: user} do
-      {:ok, user} = Ban.ban(user, NaiveDateTime.utc_now())
-      {:ok, user: user}
-    end
+    setup [:create_user, :ban_user]
 
     test "user is unbanned", %{user: user} do
       {:ok, user} = Ban.unban(user)
@@ -270,6 +264,10 @@ defmodule EpochtalkServerWeb.UserControllerTest do
 
   defp create_user(_) do
     {:ok, user} = User.create(@create_attrs)
+    {:ok, user: user}
+  end
+  defp ban_user(%{user: user}) do
+    {:ok, user} = Ban.ban(user, NaiveDateTime.utc_now())
     {:ok, user: user}
   end
 

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -175,13 +175,6 @@ defmodule EpochtalkServerWeb.UserControllerTest do
                json_response(conn, 400)
     end
 
-    test "errors with 400 if user cannot be found", %{conn: conn} do
-      conn = post(conn, Routes.user_path(conn, :login, @create_attrs))
-
-      assert %{"error" => "Bad Request", "message" => "Invalid credentials"} =
-               json_response(conn, 400)
-    end
-
     test "errors with 400 if user is not confirmed", %{conn: conn} do
       {:ok, user} = User.by_username(@login_attrs.username)
 

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -8,9 +8,6 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   @create_username "createtest"
   @create_attrs %{username: @create_username, email: "createtest@test.com", password: "password"}
 
-  # TODO(boka): refactor this into an external source
-  @auth_attrs %{username: "test", email: "test@test.com", password: "password"}
-
   @register_attrs %{
     username: "registertest",
     email: "registertest@test.com",
@@ -176,8 +173,8 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     end
 
     @tag :authenticated
-    test "errors with 400 when user is already logged in", %{conn: conn} do
-      conn = post(conn, Routes.user_path(conn, :login, @auth_attrs))
+    test "errors with 400 when user is already logged in", %{conn: conn, user_attrs: authed_user_attrs} do
+      conn = post(conn, Routes.user_path(conn, :login, authed_user_attrs))
 
       assert %{"error" => "Bad Request", "message" => "Already logged in"} =
                json_response(conn, 400)
@@ -250,9 +247,9 @@ defmodule EpochtalkServerWeb.UserControllerTest do
 
   describe "authenticate/1" do
     @tag :authenticated
-    test "success if current logged in user is authenticated", %{conn: conn} do
+    test "success if current logged in user is authenticated", %{conn: conn, user_attrs: authed_user_attrs} do
       conn = get(conn, Routes.user_path(conn, :authenticate))
-      {:ok, user} = User.by_username(@auth_attrs.username)
+      {:ok, user} = User.by_username(authed_user_attrs.username)
       assert user.id == json_response(conn, 200)["id"]
     end
 

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -68,7 +68,10 @@ defmodule EpochtalkServerWeb.UserControllerTest do
       assert registered_user.id == json_response(conn, 200)["id"]
     end
 
-    test "errors with 400 when email is already taken", %{conn: conn, user_attrs: existing_user_attrs} do
+    test "errors with 400 when email is already taken", %{
+      conn: conn,
+      user_attrs: existing_user_attrs
+    } do
       conn = post(conn, Routes.user_path(conn, :register, existing_user_attrs))
 
       assert %{"error" => "Bad Request", "message" => "Email has already been taken"} =
@@ -76,7 +79,10 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     end
 
     @tag :authenticated
-    test "errors with 400 when user is logged in", %{conn: conn, authed_user_attrs: authed_user_attrs} do
+    test "errors with 400 when user is logged in", %{
+      conn: conn,
+      authed_user_attrs: authed_user_attrs
+    } do
       conn = post(conn, Routes.user_path(conn, :register, authed_user_attrs))
 
       assert %{
@@ -86,7 +92,12 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     end
 
     test "errors with 400 when username is missing", %{conn: conn} do
-      blank_username_attrs = %{username: "", email: "blankusernametest@test.com", password: "password"}
+      blank_username_attrs = %{
+        username: "",
+        email: "blankusernametest@test.com",
+        password: "password"
+      }
+
       conn = post(conn, Routes.user_path(conn, :register, blank_username_attrs))
 
       assert %{"error" => "Bad Request", "message" => "Username can't be blank"} =
@@ -94,7 +105,12 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     end
 
     test "errors with 400 when password is missing", %{conn: conn} do
-      blank_password_attrs = %{username: "blankpasswordtest", email: "blankpasswordtest@test.com", password: ""}
+      blank_password_attrs = %{
+        username: "blankpasswordtest",
+        email: "blankpasswordtest@test.com",
+        password: ""
+      }
+
       conn = post(conn, Routes.user_path(conn, :register, blank_password_attrs))
 
       assert %{"error" => "Bad Request", "message" => "Password can't be blank"} =
@@ -150,14 +166,21 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     end
 
     @tag :authenticated
-    test "errors with 400 when user is already logged in", %{conn: conn, authed_user_attrs: authed_user_attrs} do
+    test "errors with 400 when user is already logged in", %{
+      conn: conn,
+      authed_user_attrs: authed_user_attrs
+    } do
       conn = post(conn, Routes.user_path(conn, :login, authed_user_attrs))
 
       assert %{"error" => "Bad Request", "message" => "Already logged in"} =
                json_response(conn, 400)
     end
 
-    test "errors with 400 if user is not confirmed", %{conn: conn, user: user, user_attrs: user_attrs} do
+    test "errors with 400 if user is not confirmed", %{
+      conn: conn,
+      user: user,
+      user_attrs: user_attrs
+    } do
       User
       |> Repo.get(user.id)
       |> change(%{confirmation_token: "1"})
@@ -169,7 +192,11 @@ defmodule EpochtalkServerWeb.UserControllerTest do
                json_response(conn, 400)
     end
 
-    test "errors with 403 if user is missing passhash", %{conn: conn, user: user, user_attrs: user_attrs} do
+    test "errors with 403 if user is missing passhash", %{
+      conn: conn,
+      user: user,
+      user_attrs: user_attrs
+    } do
       User
       |> Repo.get(user.id)
       |> change(%{passhash: nil})
@@ -215,7 +242,10 @@ defmodule EpochtalkServerWeb.UserControllerTest do
 
   describe "authenticate/1" do
     @tag :authenticated
-    test "success if current logged in user is authenticated", %{conn: conn, authed_user_attrs: authed_user_attrs} do
+    test "success if current logged in user is authenticated", %{
+      conn: conn,
+      authed_user_attrs: authed_user_attrs
+    } do
       conn = get(conn, Routes.user_path(conn, :authenticate))
       {:ok, user} = User.by_username(authed_user_attrs.username)
       assert user.id == json_response(conn, 200)["id"]

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -13,9 +13,6 @@ defmodule EpochtalkServerWeb.UserControllerTest do
 
   @invalid_username_confirm %{username: "invalidusernametest", token: 1}
 
-  @blank_username_attrs %{username: "", email: "blankusernametest@test.com", password: "password"}
-  @blank_password_attrs %{username: "blankpasswordtest", email: "blankpasswordtest@test.com", password: ""}
-
   @invalid_password_login_attrs %{username: "logintest", password: "1"}
   @invalid_username_login_attrs %{username: "invalidlogintest", password: "password"}
 
@@ -93,14 +90,16 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     end
 
     test "errors with 400 when username is missing", %{conn: conn} do
-      conn = post(conn, Routes.user_path(conn, :register, @blank_username_attrs))
+      blank_username_attrs = %{username: "", email: "blankusernametest@test.com", password: "password"}
+      conn = post(conn, Routes.user_path(conn, :register, blank_username_attrs))
 
       assert %{"error" => "Bad Request", "message" => "Username can't be blank"} =
                json_response(conn, 400)
     end
 
     test "errors with 400 when password is missing", %{conn: conn} do
-      conn = post(conn, Routes.user_path(conn, :register, @blank_password_attrs))
+      blank_password_attrs = %{username: "blankpasswordtest", email: "blankpasswordtest@test.com", password: ""}
+      conn = post(conn, Routes.user_path(conn, :register, blank_password_attrs))
 
       assert %{"error" => "Bad Request", "message" => "Password can't be blank"} =
                json_response(conn, 400)

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -76,7 +76,7 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     end
 
     @tag :authenticated
-    test "errors with 400 when user is logged in", %{conn: conn, user_attrs: authed_user_attrs} do
+    test "errors with 400 when user is logged in", %{conn: conn, authed_user_attrs: authed_user_attrs} do
       conn = post(conn, Routes.user_path(conn, :register, authed_user_attrs))
 
       assert %{
@@ -149,7 +149,7 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     end
 
     @tag :authenticated
-    test "errors with 400 when user is already logged in", %{conn: conn, user_attrs: authed_user_attrs} do
+    test "errors with 400 when user is already logged in", %{conn: conn, authed_user_attrs: authed_user_attrs} do
       conn = post(conn, Routes.user_path(conn, :login, authed_user_attrs))
 
       assert %{"error" => "Bad Request", "message" => "Already logged in"} =
@@ -214,7 +214,7 @@ defmodule EpochtalkServerWeb.UserControllerTest do
 
   describe "authenticate/1" do
     @tag :authenticated
-    test "success if current logged in user is authenticated", %{conn: conn, user_attrs: authed_user_attrs} do
+    test "success if current logged in user is authenticated", %{conn: conn, authed_user_attrs: authed_user_attrs} do
       conn = get(conn, Routes.user_path(conn, :authenticate))
       {:ok, user} = User.by_username(authed_user_attrs.username)
       assert user.id == json_response(conn, 200)["id"]

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -5,8 +5,6 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   alias EpochtalkServer.Models.Ban
   alias EpochtalkServer.Repo
 
-  @invalid_username_confirm %{username: "invalidusernametest", token: 1}
-
   @invalid_password_login_attrs %{username: "logintest", password: "1"}
   @invalid_username_login_attrs %{username: "invalidlogintest", password: "password"}
 
@@ -130,7 +128,8 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     end
 
     test "errors with 400 when user not found", %{conn: conn} do
-      conn = post(conn, Routes.user_path(conn, :confirm, @invalid_username_confirm))
+      invalid_username_confirm = %{username: "invalidusernametest", token: 1}
+      conn = post(conn, Routes.user_path(conn, :confirm, invalid_username_confirm))
 
       assert %{"error" => "Bad Request", "message" => "Confirmation error, account not found"} =
                json_response(conn, 400)

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -126,7 +126,7 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     end
 
     test "errors with 400 when user not found", %{conn: conn} do
-      invalid_username_confirm = %{username: "invalidusernametest", token: 1}
+      invalid_username_confirm = %{username: "invalidusernametest", token: "(anything)"}
       conn = post(conn, Routes.user_path(conn, :confirm, invalid_username_confirm))
 
       assert %{"error" => "Bad Request", "message" => "Confirmation error, account not found"} =

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -26,8 +26,6 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   @invalid_login_username_attrs %{username: "invalidlogintest", password: "password"}
 
   describe "username/2" do
-    setup [:create_user]
-
     test "found => true if username is taken", %{conn: conn, user: user} do
       conn = get(conn, Routes.user_path(conn, :username, user.username))
       assert %{"found" => true} = json_response(conn, 200)
@@ -40,8 +38,6 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   end
 
   describe "email/2" do
-    setup [:create_user]
-
     test "found => true if email is taken", %{conn: conn, user: user} do
       conn = get(conn, Routes.user_path(conn, :email, user.email))
       assert %{"found" => true} = json_response(conn, 200)

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -14,8 +14,8 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     password: "password"
   }
 
-  @confirm_invalid_username %{username: "invalidusernametest", token: 1}
-  @confirm_invalid_token %{username: @create_username, token: 1}
+  @invalid_username_confirm %{username: "invalidusernametest", token: 1}
+  @invalid_token_confirm %{username: @create_username, token: 1}
 
   @blank_username_attrs %{username: "", email: "blankusernametest@test.com", password: "password"}
   @blank_password_attrs %{username: "blankpasswordtest", email: "blankpasswordtest@test.com", password: ""}
@@ -144,14 +144,14 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     end
 
     test "errors with 400 when user not found", %{conn: conn} do
-      conn = post(conn, Routes.user_path(conn, :confirm, @confirm_invalid_username))
+      conn = post(conn, Routes.user_path(conn, :confirm, @invalid_username_confirm))
 
       assert %{"error" => "Bad Request", "message" => "Confirmation error, account not found"} =
                json_response(conn, 400)
     end
 
     test "errors with 400 when token is invalid", %{conn: conn} do
-      conn = post(conn, Routes.user_path(conn, :confirm, @confirm_invalid_token))
+      conn = post(conn, Routes.user_path(conn, :confirm, @invalid_token_confirm))
 
       assert %{"error" => "Bad Request", "message" => "Account confirmation error, invalid token"} =
                json_response(conn, 400)

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -5,8 +5,6 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   alias EpochtalkServer.Models.Ban
   alias EpochtalkServer.Repo
 
-  @invalid_username_login_attrs %{username: "invalidlogintest", password: "password"}
-
   describe "username/2" do
     test "found => true if username is taken", %{conn: conn, user: user} do
       conn = get(conn, Routes.user_path(conn, :username, user.username))
@@ -184,7 +182,8 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     end
 
     test "errors with 400 when username is not found", %{conn: conn} do
-      conn = post(conn, Routes.user_path(conn, :login, @invalid_username_login_attrs))
+      invalid_username_login_attrs = %{username: "invalidlogintest", password: "password"}
+      conn = post(conn, Routes.user_path(conn, :login, invalid_username_login_attrs))
 
       assert %{"error" => "Bad Request", "message" => "Invalid credentials"} =
                json_response(conn, 400)

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -133,8 +133,8 @@ defmodule EpochtalkServerWeb.UserControllerTest do
                json_response(conn, 400)
     end
 
-    test "errors with 400 when token is invalid", %{conn: conn, user_attrs: user_attrs} do
-      invalid_token_confirm = %{username: user_attrs.username, token: 1}
+    test "errors with 400 when token is invalid", %{conn: conn, user_attrs: valid_user_attrs} do
+      invalid_token_confirm = %{username: valid_user_attrs.username, token: 1}
       conn = post(conn, Routes.user_path(conn, :confirm, invalid_token_confirm))
 
       assert %{"error" => "Bad Request", "message" => "Account confirmation error, invalid token"} =

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -68,7 +68,7 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   describe "unban/1" do
     setup [:create_user, :ban_user]
 
-    test "user is unbanned", %{banned_user: user} do
+    test "user is unbanned", %{banned_user: banned_user} do
       {:ok, banned_user} = Ban.unban(banned_user)
       assert nil == banned_user.ban_info
     end
@@ -268,9 +268,9 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     {:ok, user} = User.create(@create_attrs)
     {:ok, user: user}
   end
-  defp ban_user(%{banned_user: user}) do
-    {:ok, user} = Ban.ban(user, NaiveDateTime.utc_now())
-    {:ok, user: user}
+  defp ban_user(%{user: user}) do
+    {:ok, banned_user} = Ban.ban(user, NaiveDateTime.utc_now())
+    {:ok, banned_user: banned_user}
   end
 
   defp create_login_user(_) do

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -22,8 +22,8 @@ defmodule EpochtalkServerWeb.UserControllerTest do
 
   @login_create_attrs %{username: "logintest", email: "logintest@test.com", password: "password"}
   @login_attrs %{username: "logintest", password: "password"}
-  @invalid_login_password_attrs %{username: "logintest", password: "1"}
-  @invalid_login_username_attrs %{username: "invalidlogintest", password: "password"}
+  @invalid_password_login_attrs %{username: "logintest", password: "1"}
+  @invalid_username_login_attrs %{username: "invalidlogintest", password: "password"}
 
   describe "username/2" do
     test "found => true if username is taken", %{conn: conn, user: user} do
@@ -206,14 +206,14 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     end
 
     test "errors with 400 when username is not found", %{conn: conn} do
-      conn = post(conn, Routes.user_path(conn, :login, @invalid_login_username_attrs))
+      conn = post(conn, Routes.user_path(conn, :login, @invalid_username_login_attrs))
 
       assert %{"error" => "Bad Request", "message" => "Invalid credentials"} =
                json_response(conn, 400)
     end
 
     test "errors with 400 when password is not found", %{conn: conn} do
-      conn = post(conn, Routes.user_path(conn, :login, @invalid_login_password_attrs))
+      conn = post(conn, Routes.user_path(conn, :login, @invalid_password_login_attrs))
 
       assert %{"error" => "Bad Request", "message" => "Invalid credentials"} =
                json_response(conn, 400)

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -129,7 +129,7 @@ defmodule EpochtalkServerWeb.UserControllerTest do
       |> Repo.update()
 
       # refresh user data
-      {:ok, confirmed_user} = User.by_username(@create_attrs.username)
+      {:ok, confirmed_user} = User.by_username(user.username)
 
       conn =
         post(

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -5,12 +5,6 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   alias EpochtalkServer.Models.Ban
   alias EpochtalkServer.Repo
 
-  @register_attrs %{
-    username: "registertest",
-    email: "registertest@test.com",
-    password: "password"
-  }
-
   @invalid_username_confirm %{username: "invalidusernametest", token: 1}
 
   @invalid_password_login_attrs %{username: "logintest", password: "1"}
@@ -67,9 +61,15 @@ defmodule EpochtalkServerWeb.UserControllerTest do
 
   describe "register/2" do
     test "user is registered and returns newly registered user with 200", %{conn: conn} do
-      conn = post(conn, Routes.user_path(conn, :register, @register_attrs))
-      {:ok, user} = User.by_username(@register_attrs.username)
-      assert user.id == json_response(conn, 200)["id"]
+      register_attrs = %{
+        username: "registertest",
+        email: "registertest@test.com",
+        password: "password"
+      }
+
+      conn = post(conn, Routes.user_path(conn, :register, register_attrs))
+      {:ok, registered_user} = User.by_username(register_attrs.username)
+      assert registered_user.id == json_response(conn, 200)["id"]
     end
 
     test "errors with 400 when email is already taken", %{conn: conn, user_attrs: existing_user_attrs} do

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -260,6 +260,6 @@ defmodule EpochtalkServerWeb.UserControllerTest do
 
   defp create_login_user(_) do
     {:ok, user} = User.create(@login_create_attrs)
-    {:ok, user: user}
+    {:ok, user: user, user_attrs: @login_create_attrs}
   end
 end

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -102,8 +102,8 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     end
 
     @tag :authenticated
-    test "errors with 400 when user is logged in", %{conn: conn} do
-      conn = post(conn, Routes.user_path(conn, :register, @auth_attrs))
+    test "errors with 400 when user is logged in", %{conn: conn, user_attrs: authed_user_attrs} do
+      conn = post(conn, Routes.user_path(conn, :register, authed_user_attrs))
 
       assert %{
                "error" => "Bad Request",

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -5,7 +5,6 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   alias EpochtalkServer.Models.Ban
   alias EpochtalkServer.Repo
 
-  @invalid_password_login_attrs %{username: "logintest", password: "1"}
   @invalid_username_login_attrs %{username: "invalidlogintest", password: "password"}
 
   describe "username/2" do
@@ -192,7 +191,8 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     end
 
     test "errors with 400 when password is not found", %{conn: conn} do
-      conn = post(conn, Routes.user_path(conn, :login, @invalid_password_login_attrs))
+      invalid_password_login_attrs = %{username: "logintest", password: "1"}
+      conn = post(conn, Routes.user_path(conn, :login, invalid_password_login_attrs))
 
       assert %{"error" => "Bad Request", "message" => "Invalid credentials"} =
                json_response(conn, 400)

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -134,7 +134,8 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     end
 
     test "errors with 400 when token is invalid", %{conn: conn, user_attrs: valid_user_attrs} do
-      invalid_token_confirm = %{username: valid_user_attrs.username, token: 1}
+      invalid_token = 1
+      invalid_token_confirm = %{username: valid_user_attrs.username, token: invalid_token}
       conn = post(conn, Routes.user_path(conn, :confirm, invalid_token_confirm))
 
       assert %{"error" => "Bad Request", "message" => "Account confirmation error, invalid token"} =

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -5,9 +5,6 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   alias EpochtalkServer.Models.Ban
   alias EpochtalkServer.Repo
 
-  @create_username "createtest"
-  @create_attrs %{username: @create_username, email: "createtest@test.com", password: "password"}
-
   @register_attrs %{
     username: "registertest",
     email: "registertest@test.com",
@@ -48,8 +45,6 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   end
 
   describe "ban/1" do
-    setup [:create_user]
-
     test "user is banned", %{user: user} do
       {:ok, user} = Ban.ban(user)
       assert user.id == user.ban_info.user_id
@@ -57,7 +52,7 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   end
 
   describe "unban/1" do
-    setup [:create_user, :ban_user]
+    setup [:ban_user]
 
     test "user is unbanned", %{banned_user: banned_user} do
       {:ok, banned_user} = Ban.unban(banned_user)
@@ -66,8 +61,6 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   end
 
   describe "handle_malicious_user/2" do
-    setup [:create_user]
-
     test "user is banned if malicious", %{conn: conn, user: user} do
       {:ok, user} = User.handle_malicious_user(user, conn.remote_ip)
       assert user.id == user.ban_info.user_id
@@ -117,8 +110,6 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   end
 
   describe "confirm/2" do
-    setup [:create_user]
-
     test "confirms user using token", %{conn: conn, user: user} do
       # confirm user
       User
@@ -240,10 +231,6 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     end
   end
 
-  defp create_user(_) do
-    {:ok, user} = User.create(@create_attrs)
-    {:ok, user: user}
-  end
   defp ban_user(%{user: user}) do
     {:ok, banned_user} = Ban.ban(user, NaiveDateTime.utc_now())
     {:ok, banned_user: banned_user}

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -174,15 +174,13 @@ defmodule EpochtalkServerWeb.UserControllerTest do
                json_response(conn, 400)
     end
 
-    test "errors with 400 if user is not confirmed", %{conn: conn} do
-      {:ok, user} = User.by_username(@login_attrs.username)
-
+    test "errors with 400 if user is not confirmed", %{conn: conn, user: user, user_attrs: user_attrs} do
       User
       |> Repo.get(user.id)
       |> change(%{confirmation_token: "1"})
       |> Repo.update()
 
-      conn = post(conn, Routes.user_path(conn, :login, @login_attrs))
+      conn = post(conn, Routes.user_path(conn, :login, user_attrs))
 
       assert %{"error" => "Bad Request", "message" => "User account not confirmed"} =
                json_response(conn, 400)

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -7,7 +7,8 @@ defmodule EpochtalkServerWeb.UserControllerTest do
 
   @create_attrs %{username: "createtest", email: "createtest@test.com", password: "password"}
 
-  @auth_attrs %{username: "authtest", email: "authtest@test.com", password: "password"}
+  # TODO(boka): refactor this into an external source
+  @auth_attrs %{username: "test", email: "test@test.com", password: "password"}
 
   @register_attrs %{
     username: "registertest",

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -70,8 +70,7 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   describe "handle_malicious_user/2" do
     setup [:create_user]
 
-    test "user is banned if malicious", %{conn: conn} do
-      {:ok, user} = User.by_username(@create_attrs.username)
+    test "user is banned if malicious", %{conn: conn, user: user} do
       {:ok, user} = User.handle_malicious_user(user, conn.remote_ip)
       assert user.id == user.ban_info.user_id
       # check that ip and hostname were banned

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -24,7 +24,8 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     end
 
     test "found => false if email is not found in the system", %{conn: conn} do
-      conn = get(conn, Routes.user_path(conn, :email, "false@test.com"))
+      invalid_email = "false@test.com"
+      conn = get(conn, Routes.user_path(conn, :email, invalid_email))
       assert %{"found" => false} = json_response(conn, 200)
     end
   end

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -48,10 +48,10 @@ defmodule EpochtalkServerWeb.UserControllerTest do
 
   describe "handle_malicious_user/2" do
     test "user is banned if malicious", %{conn: conn, user: user} do
-      {:ok, user} = User.handle_malicious_user(user, conn.remote_ip)
-      assert user.id == user.ban_info.user_id
+      {:ok, malicious_user} = User.handle_malicious_user(user, conn.remote_ip)
+      assert user.id == malicious_user.ban_info.user_id
       # check that ip and hostname were banned
-      assert user.malicious_score == 4.0416
+      assert malicious_user.malicious_score == 4.0416
     end
   end
 

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -66,9 +66,9 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   describe "unban/1" do
     setup [:create_user, :ban_user]
 
-    test "user is unbanned", %{user: user} do
-      {:ok, user} = Ban.unban(user)
-      assert nil == user.ban_info
+    test "user is unbanned", %{banned_user: user} do
+      {:ok, banned_user} = Ban.unban(banned_user)
+      assert nil == banned_user.ban_info
     end
   end
 
@@ -266,7 +266,7 @@ defmodule EpochtalkServerWeb.UserControllerTest do
     {:ok, user} = User.create(@create_attrs)
     {:ok, user: user}
   end
-  defp ban_user(%{user: user}) do
+  defp ban_user(%{banned_user: user}) do
     {:ok, user} = Ban.ban(user, NaiveDateTime.utc_now())
     {:ok, user: user}
   end

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -21,7 +21,6 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   @blank_password_attrs %{username: "blankpasswordtest", email: "blankpasswordtest@test.com", password: ""}
 
   @login_create_attrs %{username: "logintest", email: "logintest@test.com", password: "password"}
-  @login_attrs %{username: "logintest", password: "password"}
   @invalid_password_login_attrs %{username: "logintest", password: "1"}
   @invalid_username_login_attrs %{username: "invalidlogintest", password: "password"}
 

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -12,7 +12,6 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   }
 
   @invalid_username_confirm %{username: "invalidusernametest", token: 1}
-  @invalid_token_confirm %{username: @create_username, token: 1}
 
   @blank_username_attrs %{username: "", email: "blankusernametest@test.com", password: "password"}
   @blank_password_attrs %{username: "blankpasswordtest", email: "blankpasswordtest@test.com", password: ""}
@@ -139,8 +138,9 @@ defmodule EpochtalkServerWeb.UserControllerTest do
                json_response(conn, 400)
     end
 
-    test "errors with 400 when token is invalid", %{conn: conn} do
-      conn = post(conn, Routes.user_path(conn, :confirm, @invalid_token_confirm))
+    test "errors with 400 when token is invalid", %{conn: conn, user_attrs: user_attrs} do
+      invalid_token_confirm = %{username: user_attrs.username, token: 1}
+      conn = post(conn, Routes.user_path(conn, :confirm, invalid_token_confirm))
 
       assert %{"error" => "Bad Request", "message" => "Account confirmation error, invalid token"} =
                json_response(conn, 400)

--- a/test/epochtalk_server_web/controllers/user_controller_test.exs
+++ b/test/epochtalk_server_web/controllers/user_controller_test.exs
@@ -5,7 +5,8 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   alias EpochtalkServer.Models.Ban
   alias EpochtalkServer.Repo
 
-  @create_attrs %{username: "createtest", email: "createtest@test.com", password: "password"}
+  @create_username "createtest"
+  @create_attrs %{username: @create_username, email: "createtest@test.com", password: "password"}
 
   # TODO(boka): refactor this into an external source
   @auth_attrs %{username: "test", email: "test@test.com", password: "password"}
@@ -17,7 +18,7 @@ defmodule EpochtalkServerWeb.UserControllerTest do
   }
 
   @confirm_invalid_username %{username: "blank", token: 1}
-  @confirm_invalid_token %{username: "createtest", token: 1}
+  @confirm_invalid_token %{username: @create_username, token: 1}
 
   @invalid_username_attrs %{username: "", email: "invalidtest@test.com", password: "password"}
   @invalid_password_attrs %{username: "invalid", email: "invalidtest@test.com", password: ""}

--- a/test/epochtalk_server_web/helpers/acl_test.exs
+++ b/test/epochtalk_server_web/helpers/acl_test.exs
@@ -66,7 +66,9 @@ defmodule EpochtalkServerWeb.ACLTest do
     end
 
     @tag :authenticated
-    test "raises 'InvalidPermissions' error with invalid 'User' role permissions", %{authed_user: authed_user} do
+    test "raises 'InvalidPermissions' error with invalid 'User' role permissions", %{
+      authed_user: authed_user
+    } do
       assert_raise InvalidPermission,
                    ~r/^Forbidden, invalid permissions to perform this action/,
                    fn ->
@@ -90,11 +92,17 @@ defmodule EpochtalkServerWeb.ACLTest do
   describe "allow!/3" do
     @tag :authenticated
     test "returns :ok with valid 'User' role permissions", %{authed_user: authed_user} do
-      assert ACL.allow!(authed_user, "boards.allCategories", "You cannot query all categories") == :ok
+      assert ACL.allow!(authed_user, "boards.allCategories", "You cannot query all categories") ==
+               :ok
+
       assert ACL.allow!(authed_user, "posts.create", "You cannot create posts") == :ok
       assert ACL.allow!(authed_user, "threads.create", "You cannot create threads") == :ok
 
-      assert ACL.allow!(authed_user, "boards.allCategories.allow", "You cannot query all categories") ==
+      assert ACL.allow!(
+               authed_user,
+               "boards.allCategories.allow",
+               "You cannot query all categories"
+             ) ==
                :ok
 
       assert ACL.allow!(authed_user, "posts.create.allow", "You cannot create posts") == :ok

--- a/test/epochtalk_server_web/helpers/acl_test.exs
+++ b/test/epochtalk_server_web/helpers/acl_test.exs
@@ -5,13 +5,13 @@ defmodule EpochtalkServerWeb.ACLTest do
 
   describe "allow!/2" do
     @tag :authenticated
-    test "returns :ok with valid 'User' role permissions", %{user: user} do
-      assert ACL.allow!(user, "boards.allCategories") == :ok
-      assert ACL.allow!(user, "posts.create") == :ok
-      assert ACL.allow!(user, "threads.create") == :ok
-      assert ACL.allow!(user, "boards.allCategories.allow") == :ok
-      assert ACL.allow!(user, "posts.create.allow") == :ok
-      assert ACL.allow!(user, "threads.create.allow") == :ok
+    test "returns :ok with valid 'User' role permissions", %{authed_user: authed_user} do
+      assert ACL.allow!(authed_user, "boards.allCategories") == :ok
+      assert ACL.allow!(authed_user, "posts.create") == :ok
+      assert ACL.allow!(authed_user, "threads.create") == :ok
+      assert ACL.allow!(authed_user, "boards.allCategories.allow") == :ok
+      assert ACL.allow!(authed_user, "posts.create.allow") == :ok
+      assert ACL.allow!(authed_user, "threads.create.allow") == :ok
     end
 
     test "defaults to 'anonymous' role if not authenticated" do
@@ -66,39 +66,39 @@ defmodule EpochtalkServerWeb.ACLTest do
     end
 
     @tag :authenticated
-    test "raises 'InvalidPermissions' error with invalid 'User' role permissions", %{user: user} do
+    test "raises 'InvalidPermissions' error with invalid 'User' role permissions", %{authed_user: authed_user} do
       assert_raise InvalidPermission,
                    ~r/^Forbidden, invalid permissions to perform this action/,
                    fn ->
-                     ACL.allow!(user, "roles.update")
+                     ACL.allow!(authed_user, "roles.update")
                    end
 
       assert_raise InvalidPermission,
                    ~r/^Forbidden, invalid permissions to perform this action/,
                    fn ->
-                     ACL.allow!(user, "roles.create")
+                     ACL.allow!(authed_user, "roles.create")
                    end
 
       assert_raise InvalidPermission,
                    ~r/^Forbidden, invalid permissions to perform this action/,
                    fn ->
-                     ACL.allow!(user, "adminSettings.find")
+                     ACL.allow!(authed_user, "adminSettings.find")
                    end
     end
   end
 
   describe "allow!/3" do
     @tag :authenticated
-    test "returns :ok with valid 'User' role permissions", %{user: user} do
-      assert ACL.allow!(user, "boards.allCategories", "You cannot query all categories") == :ok
-      assert ACL.allow!(user, "posts.create", "You cannot create posts") == :ok
-      assert ACL.allow!(user, "threads.create", "You cannot create threads") == :ok
+    test "returns :ok with valid 'User' role permissions", %{authed_user: authed_user} do
+      assert ACL.allow!(authed_user, "boards.allCategories", "You cannot query all categories") == :ok
+      assert ACL.allow!(authed_user, "posts.create", "You cannot create posts") == :ok
+      assert ACL.allow!(authed_user, "threads.create", "You cannot create threads") == :ok
 
-      assert ACL.allow!(user, "boards.allCategories.allow", "You cannot query all categories") ==
+      assert ACL.allow!(authed_user, "boards.allCategories.allow", "You cannot query all categories") ==
                :ok
 
-      assert ACL.allow!(user, "posts.create.allow", "You cannot create posts") == :ok
-      assert ACL.allow!(user, "threads.create.allow", "You cannot create threads") == :ok
+      assert ACL.allow!(authed_user, "posts.create.allow", "You cannot create posts") == :ok
+      assert ACL.allow!(authed_user, "threads.create.allow", "You cannot create threads") == :ok
     end
 
     test "raises 'InvalidPermissions' error with unauthenticated connection" do
@@ -152,17 +152,17 @@ defmodule EpochtalkServerWeb.ACLTest do
 
     @tag :authenticated
     test "raises 'InvalidPermissions' error with custom message with invalid 'User' role permissions",
-         %{user: user} do
+         %{authed_user: authed_user} do
       assert_raise InvalidPermission, ~r/^You cannot update roles/, fn ->
-        ACL.allow!(user, "roles.update", "You cannot update roles")
+        ACL.allow!(authed_user, "roles.update", "You cannot update roles")
       end
 
       assert_raise InvalidPermission, ~r/^You cannot create roles/, fn ->
-        ACL.allow!(user, "roles.create", "You cannot create roles")
+        ACL.allow!(authed_user, "roles.create", "You cannot create roles")
       end
 
       assert_raise InvalidPermission, ~r/^You cannot fetch admin settings/, fn ->
-        ACL.allow!(user, "adminSettings.find", "You cannot fetch admin settings")
+        ACL.allow!(authed_user, "adminSettings.find", "You cannot fetch admin settings")
       end
     end
   end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -15,6 +15,9 @@ defmodule EpochtalkServerWeb.ConnCase do
   this option is not recommended for other databases.
   """
 
+  # username from user seed in `mix test` (see mix.exs)
+  @test_username "test"
+
   use ExUnit.CaseTemplate
 
   using do
@@ -42,7 +45,7 @@ defmodule EpochtalkServerWeb.ConnCase do
     end
 
     if tags[:authenticated] do
-      {:ok, user} = User.by_username("test")
+      {:ok, user} = User.by_username(@test_username)
 
       conn = Phoenix.ConnTest.build_conn()
       {:ok, user, token, conn} = Session.create(user, false, conn)

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -42,8 +42,7 @@ defmodule EpochtalkServerWeb.ConnCase do
     end
 
     if tags[:authenticated] do
-      {:ok, user} =
-        User.create(%{username: "authtest", email: "authtest@test.com", password: "password"})
+      {:ok, user} = User.by_username("test")
 
       conn = Phoenix.ConnTest.build_conn()
       {:ok, user, token, conn} = Session.create(user, false, conn)

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -15,8 +15,15 @@ defmodule EpochtalkServerWeb.ConnCase do
   this option is not recommended for other databases.
   """
 
-  # username from user seed in `mix test` (see mix.exs)
+  # username/email/password from user seed in `mix test` (see mix.exs)
   @test_username "test"
+  @test_email "test@test.com"
+  @test_password "password"
+  @test_user_attrs %{
+    username: @test_username,
+    email: @test_email,
+    password: @test_password
+  }
 
   use ExUnit.CaseTemplate
 
@@ -49,7 +56,7 @@ defmodule EpochtalkServerWeb.ConnCase do
 
       conn = Phoenix.ConnTest.build_conn()
       {:ok, user, token, conn} = Session.create(user, false, conn)
-      {:ok, conn: conn, user: user, token: token}
+      {:ok, conn: conn, user: user, token: token, user_attrs: @test_user_attrs}
     else
       {:ok, conn: Phoenix.ConnTest.build_conn()}
     end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -56,7 +56,7 @@ defmodule EpochtalkServerWeb.ConnCase do
     if tags[:authenticated] do
       conn = Phoenix.ConnTest.build_conn()
       {:ok, user, token, conn} = Session.create(user, false, conn)
-      {:ok, conn: conn, user: user, token: token, user_attrs: @test_user_attrs}
+      {:ok, conn: conn, authed_user: user, token: token, authed_user_attrs: @test_user_attrs}
     else
       {:ok, conn: Phoenix.ConnTest.build_conn(), user: user, user_attrs: @test_user_attrs}
     end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -51,14 +51,14 @@ defmodule EpochtalkServerWeb.ConnCase do
       Ecto.Adapters.SQL.Sandbox.mode(EpochtalkServer.Repo, {:shared, self()})
     end
 
-    if tags[:authenticated] do
-      {:ok, user} = User.by_username(@test_username)
+    {:ok, user} = User.by_username(@test_username)
 
+    if tags[:authenticated] do
       conn = Phoenix.ConnTest.build_conn()
       {:ok, user, token, conn} = Session.create(user, false, conn)
       {:ok, conn: conn, user: user, token: token, user_attrs: @test_user_attrs}
     else
-      {:ok, conn: Phoenix.ConnTest.build_conn()}
+      {:ok, conn: Phoenix.ConnTest.build_conn(), user: user, user_attrs: @test_user_attrs}
     end
   end
 end


### PR DESCRIPTION
make tests great again

* seed test user in database

* improve conn case

    * export user and user_attrs by default

    * export authed_user and authed_user_attrs when :authenticated

* remove redundant user creation

* remove redundant tests

* use conn case user instead of calling User.by_username

* improve variable names

* move single-use module attributes into tests as variables

* remove user create methods (rely on ecto sandbox rollbacks)