### PR TITLE
Delete session

### DIFF
--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -108,7 +108,7 @@ defmodule EpochtalkServer.Session do
   @doc """
   Gets all session ids for a specific user_id
   """
-  @spec get_sessions(user_id :: String.t()) ::
+  @spec get_sessions(user_id :: non_neg_integer) ::
           {:ok, sessions_ids :: [String.t()]}
           | {:error, atom() | Redix.Error.t() | Redix.ConnectionError.t()}
   def get_sessions(user_id) do

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -289,10 +289,8 @@ defmodule EpochtalkServer.Session do
     delete_expired_sessions(user_id)
     # save session id to redis under "user:{user_id}:sessions"
     session_key = generate_key(user_id, "sessions")
-    # current unix time (default :seconds)
-    now = DateTime.utc_now() |> DateTime.to_unix()
     # intended unix expiration of this session
-    unix_expiration = now + ttl
+    unix_expiration = current_time() + ttl
 
     # add new session, noting unix expiration
     result =

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -133,6 +133,9 @@ defmodule EpochtalkServer.Session do
   def delete(conn) do
     # get user from guardian resource
     %{ id: user_id } = Guardian.Plug.current_resource(conn)
+    # get session_id from jti in jwt token
+    %{claims: %{"jti" => session_id}} = Guardian.Plug.current_token(conn)
+                                        |> Guardian.peek
 
     # delete session id from redis under "user:{user_id}:sessions"
     session_key = generate_key(user_id, "sessions")

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -140,8 +140,11 @@ defmodule EpochtalkServer.Session do
     # delete session id from redis under "user:{user_id}:sessions"
     session_key = generate_key(user_id, "sessions")
 
-    case Redix.command(:redix, ["SREM", session_key, session]) do
-      {:ok, _} -> {:ok, user_id}
+    case Redix.command(:redix, ["ZREM", session_key, session_id]) do
+      {:ok, _} ->
+        # sign user out
+        conn = Guardian.Plug.sign_out(conn)
+        {:ok, conn}
       {:error, error} -> {:error, error}
     end
   end

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -119,9 +119,14 @@ defmodule EpochtalkServer.Session do
   end
 
   defp is_active_for_user_id(session_id, user_id) do
-    case get_sessions(user_id) do
+    session_key = generate_key(user_id, "sessions")
+    # check ZSCORE for user_id:session_id pair
+    # returns score if it is a member of the set
+    # returns nil if not a member
+    case Redix.command(:redix, ["ZSCORE", session_key, session_id]) do
       {:error, error} -> {:error, error}
-      {:ok, session_ids} -> Enum.member?(session_ids, session_id)
+      {:ok, nil} -> false
+      {:ok, _score} -> true
     end
   end
 

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -160,12 +160,7 @@ defmodule EpochtalkServer.Session do
   def delete_sessions(%User{} = user) do
     # delete session id from redis under "user:{user_id}:sessions"
     session_key = generate_key(user.id, "sessions")
-
-    case Redix.command(:redix, ["SPOP", session_key]) do
-      {:ok, nil} -> :ok
-      # repeat until redix returns nil
-      _ -> delete_sessions(user)
-    end
+    Redix.command(:redix, ["DEL", session_key])
   end
 
   defp save(%User{} = user, session_id, ttl) do

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -106,10 +106,10 @@ defmodule EpochtalkServer.Session do
   end
 
   @doc """
-  Gets all sessions for a specific user_id
+  Gets all session ids for a specific user_id
   """
   @spec get_sessions(user_id :: String.t()) ::
-          {:ok, user :: User.t(), sessions :: [String.t()]}
+          {:ok, sessions_ids :: [String.t()]}
           | {:error, atom() | Redix.Error.t() | Redix.ConnectionError.t()}
   def get_sessions(user_id) do
     # get session id's from redis under "user:{user_id}:sessions"
@@ -121,7 +121,7 @@ defmodule EpochtalkServer.Session do
   defp is_active_for_user_id(session_id, user_id) do
     case get_sessions(user_id) do
       {:error, error} -> {:error, error}
-      session_ids -> Enum.member?(session_ids, session_id)
+      {:ok, session_ids} -> Enum.member?(session_ids, session_id)
     end
   end
 

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -277,9 +277,12 @@ defmodule EpochtalkServer.Session do
     maybe_extend_ttl(ban_key, ttl, old_ttl)
   end
 
-  # these two rules ensure that sessions will eventually be deleted:
+  # session storage uses "pseudo-expiry" (via redis sorted-set score)
+  # these rules ensure that session storage will not grow indefinitely:
+  #
   # on every new session add,
-  #   clean (delete) expired sessions
+  #   clean (delete) expired sessions by expiry
+  #   add the new session, with expiry
   #   ttl expiry for this key will delete all sessions in the set
   defp add_session(user_id, session_id, ttl) do
     # delete expired sessions

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -119,29 +119,12 @@ defmodule EpochtalkServer.Session do
   end
 
   defp is_active_for_user_id(session_id, user_id) do
-    case get_session_ids_by_user_id(user_id) do
+    case get_sessions(%User{user_id: user_id}) do
       {:error, error} ->
         {:error, error}
 
       session_ids ->
         Enum.member?(session_ids, session_id)
-    end
-  end
-
-  defp get_sessions_by_user_id(user_id) do
-    # get session id's from redis under "user:{user_id}:sessions"
-    session_key = generate_key(user_id, "sessions")
-
-    case Redix.command(:redix, ["SMEMBERS", session_key]) do
-      {:ok, sessions} -> sessions
-      {:error, error} -> {:error, error}
-    end
-  end
-
-  defp get_session_ids_by_user_id(user_id) do
-    case get_sessions_by_user_id(user_id) do
-      {:error, error} -> {:error, error}
-      sessions -> Enum.map(sessions, &(String.split(&1, ":") |> List.first()))
     end
   end
 

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -318,6 +318,11 @@ defmodule EpochtalkServer.Session do
     end)
   end
 
+  # current unix time (default :seconds)
+  defp current_time() do
+    DateTime.utc_now() |> DateTime.to_unix()
+  end
+
   defp generate_key(user_id, "user"), do: "user:#{user_id}"
   defp generate_key(user_id, type), do: "user:#{user_id}:#{type}"
 

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -106,12 +106,12 @@ defmodule EpochtalkServer.Session do
   end
 
   @doc """
-  Gets all sessions for a specific `User`
+  Gets all sessions for a specific user_id
   """
-  @spec get_sessions(user :: User.t()) ::
+  @spec get_sessions(user_id :: String.t()) ::
           {:ok, user :: User.t(), sessions :: [String.t()]}
           | {:error, atom() | Redix.Error.t() | Redix.ConnectionError.t()}
-  def get_sessions(%User{} = user) do
+  def get_sessions(user_id) do
     # get session id's from redis under "user:{user_id}:sessions"
     session_key = generate_key(user.id, "sessions")
 
@@ -119,12 +119,9 @@ defmodule EpochtalkServer.Session do
   end
 
   defp is_active_for_user_id(session_id, user_id) do
-    case get_sessions(%User{user_id: user_id}) do
-      {:error, error} ->
-        {:error, error}
-
-      session_ids ->
-        Enum.member?(session_ids, session_id)
+    case get_sessions(user_id) do
+      {:error, error} -> {:error, error}
+      session_ids -> Enum.member?(session_ids, session_id)
     end
   end
 

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -115,20 +115,7 @@ defmodule EpochtalkServer.Session do
     # get session id's from redis under "user:{user_id}:sessions"
     session_key = generate_key(user.id, "sessions")
 
-    case Redix.command(:redix, ["SMEMBERS", session_key]) do
-      {:ok, sessions} ->
-        session_ids =
-          sessions
-          |> Enum.map(fn session ->
-            [session_id, _expiration] = session |> String.split(":")
-            session_id
-          end)
-
-        {:ok, user, session_ids}
-
-      {:error, error} ->
-        {:error, error}
-    end
+    Redix.command(:redix, ["ZRANGE", session_key, 0, -1])
   end
 
   defp is_active_for_user_id(session_id, user_id) do

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -311,6 +311,17 @@ defmodule EpochtalkServer.Session do
     result
   end
 
+  defp delete_expired_sessions(user_id) do
+    get_sessions_by_user_id(user_id)
+    |> Enum.each(fn session ->
+      [_session_id, expiration] = String.split(session, ":")
+
+      if String.to_integer(expiration) < now do
+        delete_session_by_user_id(user_id, session)
+      end
+    end)
+  end
+
   defp generate_key(user_id, "user"), do: "user:#{user_id}"
   defp generate_key(user_id, type), do: "user:#{user_id}:#{type}"
 

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -260,10 +260,10 @@ defmodule EpochtalkServer.Session do
   #   add the new session, with expiry
   #   ttl expiry for this key will delete all sessions in the set
   defp add_session(user_id, session_id, ttl) do
-    # delete expired sessions
-    delete_expired_sessions(user_id)
     # save session id to redis under "user:{user_id}:sessions"
     session_key = generate_key(user_id, "sessions")
+    # delete expired sessions
+    delete_expired_sessions(session_key)
     # intended unix expiration of this session
     unix_expiration = current_time() + ttl
 
@@ -276,8 +276,8 @@ defmodule EpochtalkServer.Session do
   end
 
   # delete expired sessions by expiration (sorted set score)
-  defp delete_expired_sessions(user_id) do
-    Redix.command(:redix, ["ZREMRANGEBYSCORE", "-inf", current_time()])
+  defp delete_expired_sessions(session_key) do
+    Redix.command(:redix, ["ZREMRANGEBYSCORE", session_key, "-inf", current_time()])
   end
 
   # current unix time (default :seconds)

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -293,12 +293,7 @@ defmodule EpochtalkServer.Session do
     unix_expiration = current_time() + ttl
 
     # add new session, noting unix expiration
-    result =
-      Redix.command(:redix, [
-        "SADD",
-        session_key,
-        session_id <> ":" <> Integer.to_string(unix_expiration)
-      ])
+    result = Redix.command(:redix, ["ZADD", session_key, unix_expiration, session_id])
 
     # set ttl
     maybe_extend_ttl(session_key, ttl)

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -156,7 +156,7 @@ defmodule EpochtalkServer.Session do
   @doc """
   Deletes every session instance for the specified `User`
   """
-  @spec delete_sessions(user :: User.t()) :: :ok
+  @spec delete_sessions(user :: User.t()) :: {:ok, non_neg_integer} | Redix.ConnectionError.t()
   def delete_sessions(%User{} = user) do
     # delete session id from redis under "user:{user_id}:sessions"
     session_key = generate_key(user.id, "sessions")

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -129,13 +129,15 @@ defmodule EpochtalkServer.Session do
   Deletes the session specified in conn
   """
   @spec delete(conn :: Plug.Conn.t()) ::
-          {:ok, conn :: Plug.Conn.t()} | {:error, atom() | Redix.Error.t() | Redix.ConnectionError.t()}
+          {:ok, conn :: Plug.Conn.t()}
+          | {:error, atom() | Redix.Error.t() | Redix.ConnectionError.t()}
   def delete(conn) do
     # get user from guardian resource
-    %{ id: user_id } = Guardian.Plug.current_resource(conn)
+    %{id: user_id} = Guardian.Plug.current_resource(conn)
     # get session_id from jti in jwt token
-    %{claims: %{"jti" => session_id}} = Guardian.Plug.current_token(conn)
-                                        |> Guardian.peek
+    %{claims: %{"jti" => session_id}} =
+      Guardian.Plug.current_token(conn)
+      |> Guardian.peek()
 
     # delete session id from redis under "user:{user_id}:sessions"
     session_key = generate_key(user_id, "sessions")
@@ -145,7 +147,9 @@ defmodule EpochtalkServer.Session do
         # sign user out
         conn = Guardian.Plug.sign_out(conn)
         {:ok, conn}
-      {:error, error} -> {:error, error}
+
+      {:error, error} ->
+        {:error, error}
     end
   end
 

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -305,15 +305,9 @@ defmodule EpochtalkServer.Session do
     result
   end
 
+  # delete expired sessions by expiration (sorted set score)
   defp delete_expired_sessions(user_id) do
-    get_sessions_by_user_id(user_id)
-    |> Enum.each(fn session ->
-      [_session_id, expiration] = String.split(session, ":")
-
-      if String.to_integer(expiration) < now do
-        delete_session_by_user_id(user_id, session)
-      end
-    end)
+    Redix.command(:redix, ["ZREMRANGEBYSCORE", "-inf", current_time()])
   end
 
   # current unix time (default :seconds)

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -278,8 +278,9 @@ defmodule EpochtalkServer.Session do
   end
 
   # these two rules ensure that sessions will eventually be deleted:
-  # clean expired sessions and add a new one
-  # ttl expiry for this key will delete all sessions in the set
+  # on every new session add,
+  #   clean (delete) expired sessions
+  #   ttl expiry for this key will delete all sessions in the set
   defp add_session(user_id, session_id, ttl) do
     # save session id to redis under "user:{user_id}:sessions"
     session_key = generate_key(user_id, "sessions")

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -113,7 +113,7 @@ defmodule EpochtalkServer.Session do
           | {:error, atom() | Redix.Error.t() | Redix.ConnectionError.t()}
   def get_sessions(user_id) do
     # get session id's from redis under "user:{user_id}:sessions"
-    session_key = generate_key(user.id, "sessions")
+    session_key = generate_key(user_id, "sessions")
 
     Redix.command(:redix, ["ZRANGE", session_key, 0, -1])
   end

--- a/lib/epochtalk_server_web/controllers/user_controller.ex
+++ b/lib/epochtalk_server_web/controllers/user_controller.ex
@@ -159,7 +159,6 @@ defmodule EpochtalkServerWeb.UserController do
   Logs out the logged in `User`
 
   - TODO(boka): check if user is on page that requires auth
-  - TODO(boka): Delete users session
   """
   def logout(conn, _attrs) do
     with {:auth, true} <- {:auth, Guardian.Plug.authenticated?(conn)},

--- a/lib/epochtalk_server_web/controllers/user_controller.ex
+++ b/lib/epochtalk_server_web/controllers/user_controller.ex
@@ -164,9 +164,8 @@ defmodule EpochtalkServerWeb.UserController do
     with {:auth, true} <- {:auth, Guardian.Plug.authenticated?(conn)},
          user <- Guardian.Plug.current_resource(conn),
          token <- Guardian.Plug.current_token(conn),
-         result <-
-           EpochtalkServerWeb.Endpoint.broadcast("user:#{user.id}", "logout", %{token: token}),
          {:ok, conn} <- Session.delete(conn) do
+      EpochtalkServerWeb.Endpoint.broadcast("user:#{user.id}", "logout", %{token: token})
       render(conn, "logout.json", data: %{success: true})
     else
       {:auth, false} -> ErrorHelpers.render_json_error(conn, 400, "Not logged in")

--- a/lib/epochtalk_server_web/controllers/user_controller.ex
+++ b/lib/epochtalk_server_web/controllers/user_controller.ex
@@ -164,7 +164,8 @@ defmodule EpochtalkServerWeb.UserController do
     with {:auth, true} <- {:auth, Guardian.Plug.authenticated?(conn)},
          user <- Guardian.Plug.current_resource(conn),
          token <- Guardian.Plug.current_token(conn),
-         result <- EpochtalkServerWeb.Endpoint.broadcast("user:#{user.id}", "logout", %{token: token}),
+         result <-
+           EpochtalkServerWeb.Endpoint.broadcast("user:#{user.id}", "logout", %{token: token}),
          {:ok, conn} <- Session.delete(conn) do
       render(conn, "logout.json", data: %{success: true})
     else

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -33,6 +33,20 @@ defmodule EpochtalkServerWeb.SessionTest do
     end
   end
 
+  describe "delete/1" do
+    test "deletes authenticated user's session", %{conn: conn, user: user} do
+      # create a new user session (don't use :authenticated)
+      remember_me = false
+      {:ok, authed_user, _token, authed_con} = Session.create(user, remember_me, conn)
+      assert Guardian.Plug.authenticated?(authed_con) == true
+      session_id = authed_con.private.guardian_default_claims["jti"]
+      {:ok, resource} = Session.get_resource(authed_user.id, session_id)
+      %{id: session_user_id, username: session_user_username} = resource
+      assert session_user_id == authed_user.id
+      assert session_user_username == authed_user.username
+    end
+  end
+
   describe "create/3 expiration/ttl" do
     setup [:flush_redis]
 

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -49,7 +49,9 @@ defmodule EpochtalkServerWeb.SessionTest do
       unauthed_conn = delete(conn, Routes.user_path(conn, :logout))
       assert Guardian.Plug.authenticated?(unauthed_conn) == false
       unauthed_resource = Session.get_resource(authed_user.id, session_id)
-      assert unauthed_resource == {:error, "No session for user_id #{authed_user.id} with id #{session_id}"}
+
+      assert unauthed_resource ==
+               {:error, "No session for user_id #{authed_user.id} with id #{session_id}"}
     end
   end
 

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -59,45 +59,76 @@ defmodule EpochtalkServerWeb.SessionTest do
     test "deletes an expired user session when logging in", %{conn: conn, user: user} do
       remember_me = false
       # create session that should be deleted
-      {:ok, authed_user_to_delete, _token, authed_conn_to_delete} = Session.create(user, remember_me, conn)
+      {:ok, authed_user_to_delete, _token, authed_conn_to_delete} =
+        Session.create(user, remember_me, conn)
+
       session_id_to_delete = authed_conn_to_delete.private.guardian_default_claims["jti"]
       # create session that shouldn't be deleted
-      {:ok, authed_user_to_persist, _token, authed_conn_to_persist} = Session.create(user, remember_me, conn)
+      {:ok, authed_user_to_persist, _token, authed_conn_to_persist} =
+        Session.create(user, remember_me, conn)
+
       session_id_to_persist = authed_conn_to_persist.private.guardian_default_claims["jti"]
       # check that all sessions are active
       {:ok, resource_to_delete} = Session.get_resource(user.id, session_id_to_delete)
-      %{id: session_user_id_to_delete, username: session_user_username_to_delete} = resource_to_delete
+
+      %{id: session_user_id_to_delete, username: session_user_username_to_delete} =
+        resource_to_delete
+
       assert session_user_id_to_delete == user.id
       assert session_user_username_to_delete == user.username
       {:ok, resource_to_persist} = Session.get_resource(user.id, session_id_to_persist)
-      %{id: session_user_id_to_persist, username: session_user_username_to_persist} = resource_to_persist
+
+      %{id: session_user_id_to_persist, username: session_user_username_to_persist} =
+        resource_to_persist
+
       assert session_user_id_to_persist == user.id
       assert session_user_username_to_persist == user.username
       # change expiration of session to delete to UTC 0
       expiration_utc = 0
-      Redix.command(:redix, ["ZADD", "user:#{user.id}:sessions", expiration_utc, session_id_to_delete])
+
+      Redix.command(:redix, [
+        "ZADD",
+        "user:#{user.id}:sessions",
+        expiration_utc,
+        session_id_to_delete
+      ])
+
       # create a new session (should delete expired sessions)
       {:ok, new_authed_user, _token, new_authed_conn} = Session.create(user, remember_me, conn)
       new_session_id = new_authed_conn.private.guardian_default_claims["jti"]
       # check that active sessions are still active
       {:ok, resource_to_persist} = Session.get_resource(user.id, session_id_to_persist)
-      %{id: session_user_id_to_persist, username: session_user_username_to_persist} = resource_to_persist
+
+      %{id: session_user_id_to_persist, username: session_user_username_to_persist} =
+        resource_to_persist
+
       assert session_user_id_to_persist == user.id
       assert session_user_username_to_persist == user.username
-      authenticate_persisted_conn = get(authed_conn_to_persist, Routes.user_path(authed_conn_to_persist, :authenticate))
+
+      authenticate_persisted_conn =
+        get(authed_conn_to_persist, Routes.user_path(authed_conn_to_persist, :authenticate))
+
       assert user.id == json_response(authenticate_persisted_conn, 200)["id"]
       {:ok, new_resource} = Session.get_resource(user.id, new_session_id)
       %{id: new_session_user_id, username: new_session_user_username} = new_resource
       assert new_session_user_id == user.id
       assert new_session_user_username == user.username
-      new_authenticate_conn = get(new_authed_conn, Routes.user_path(new_authed_conn, :authenticate))
+
+      new_authenticate_conn =
+        get(new_authed_conn, Routes.user_path(new_authed_conn, :authenticate))
+
       assert user.id == json_response(new_authenticate_conn, 200)["id"]
       # check that expired session is not active
       unauthed_resource = Session.get_resource(user.id, session_id_to_delete)
+
       assert unauthed_resource ==
                {:error, "No session for user_id #{user.id} with id #{session_id_to_delete}"}
-      authenticate_deleted_conn = get(authed_conn_to_delete, Routes.user_path(authed_conn_to_delete, :authenticate))
-      assert %{"error" => "Unauthorized", "message" => "No resource found"} = json_response(authenticate_deleted_conn, 401)
+
+      authenticate_deleted_conn =
+        get(authed_conn_to_delete, Routes.user_path(authed_conn_to_delete, :authenticate))
+
+      assert %{"error" => "Unauthorized", "message" => "No resource found"} =
+               json_response(authenticate_deleted_conn, 401)
     end
   end
 

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -55,6 +55,52 @@ defmodule EpochtalkServerWeb.SessionTest do
     end
   end
 
+  describe "create/3 session expiration" do
+    test "deletes an expired user session when logging in", %{conn: conn, user: user} do
+      remember_me = false
+      # create session that should be deleted
+      {:ok, authed_user_to_delete, _token, authed_conn_to_delete} = Session.create(user, remember_me, conn)
+      session_id_to_delete = authed_conn_to_delete.private.guardian_default_claims["jti"]
+      # create session that shouldn't be deleted
+      {:ok, authed_user_to_persist, _token, authed_conn_to_persist} = Session.create(user, remember_me, conn)
+      session_id_to_persist = authed_conn_to_persist.private.guardian_default_claims["jti"]
+      # check that all sessions are active
+      {:ok, resource_to_delete} = Session.get_resource(user.id, session_id_to_delete)
+      %{id: session_user_id_to_delete, username: session_user_username_to_delete} = resource_to_delete
+      assert session_user_id_to_delete == user.id
+      assert session_user_username_to_delete == user.username
+      {:ok, resource_to_persist} = Session.get_resource(user.id, session_id_to_persist)
+      %{id: session_user_id_to_persist, username: session_user_username_to_persist} = resource_to_persist
+      assert session_user_id_to_persist == user.id
+      assert session_user_username_to_persist == user.username
+      # change expiration of session to delete to UTC 0
+      expiration_utc = 0
+      Redix.command(:redix, ["ZADD", "user:#{user.id}:sessions", expiration_utc, session_id_to_delete])
+      # create a new session (should delete expired sessions)
+      {:ok, new_authed_user, _token, new_authed_conn} = Session.create(user, remember_me, conn)
+      new_session_id = new_authed_conn.private.guardian_default_claims["jti"]
+      # check that active sessions are still active
+      {:ok, resource_to_persist} = Session.get_resource(user.id, session_id_to_persist)
+      %{id: session_user_id_to_persist, username: session_user_username_to_persist} = resource_to_persist
+      assert session_user_id_to_persist == user.id
+      assert session_user_username_to_persist == user.username
+      authenticate_persisted_conn = get(authed_conn_to_persist, Routes.user_path(authed_conn_to_persist, :authenticate))
+      assert user.id == json_response(authenticate_persisted_conn, 200)["id"]
+      {:ok, new_resource} = Session.get_resource(user.id, new_session_id)
+      %{id: new_session_user_id, username: new_session_user_username} = new_resource
+      assert new_session_user_id == user.id
+      assert new_session_user_username == user.username
+      new_authenticate_conn = get(new_authed_conn, Routes.user_path(new_authed_conn, :authenticate))
+      assert user.id == json_response(new_authenticate_conn, 200)["id"]
+      # check that expired session is not active
+      unauthed_resource = Session.get_resource(user.id, session_id_to_delete)
+      assert unauthed_resource ==
+               {:error, "No session for user_id #{user.id} with id #{session_id_to_delete}"}
+      authenticate_deleted_conn = get(authed_conn_to_delete, Routes.user_path(authed_conn_to_delete, :authenticate))
+      assert %{"error" => "Unauthorized", "message" => "No resource found"} = json_response(authenticate_deleted_conn, 401)
+    end
+  end
+
   describe "create/3 expiration/ttl" do
     setup [:flush_redis]
 


### PR DESCRIPTION
finish todo; handle deleting user session

refactor session storage to allow deleting of sessions by id:

* replace redis set implementation with redis sorted set
    * expiration is now handled through sorted set scores
    * no string splitting or concatenating needs to be done; set values do not need to be generated with expirations
    * expiration deletion happens for all expiration scores below current date
    * deletion by session id enabled because it is now possible to look up sessions by id without having to know the expiration

refactor session delete

* combine deletes into a single method
* infer user info from conn

delete session in user controller

* deletes session
* session delete calls guardian logout

test session delete
(confirm that delete works through logout route; fail case does not need to be tested, since it's covered in user controller test)