### PR TITLE
Session test

### DIFF
--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -13,7 +13,7 @@ conventions.  Please refer to these guidelines!
 * Write [code](https://en.wikipedia.org/wiki/Computer_programming)
   in [Elixir](https://elixir-lang.org/) to implement your feature
 
-  (Instructions for your computer to do things)
+* Use Logger instead of IO.puts/inspect
 
 * Commit code using [Angular Commit Message](https://gist.github.com/brianclements/841ea7bffdb01346392c)
   conventions.

--- a/config/test.exs
+++ b/config/test.exs
@@ -25,7 +25,8 @@ config :epochtalk_server, EpochtalkServer.Mailer, adapter: Swoosh.Adapters.Test
 
 # Print only warnings and errors during test
 # Accept module and parameters
-config :logger, :console, level: :warning,
+config :logger, :console,
+  level: :warning,
   format: "[$level] $message $metadata\n",
   metadata: [:module, :parameters]
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -24,7 +24,10 @@ config :epochtalk_server, EpochtalkServerWeb.Endpoint,
 config :epochtalk_server, EpochtalkServer.Mailer, adapter: Swoosh.Adapters.Test
 
 # Print only warnings and errors during test
-config :logger, level: :warning
+# Accept module and parameters
+config :logger, :console, level: :warning,
+  format: "[$level] $message $metadata\n",
+  metadata: [:module, :parameters]
 
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime

--- a/lib/epochtalk_server/models/banned_address.ex
+++ b/lib/epochtalk_server/models/banned_address.ex
@@ -9,6 +9,9 @@ defmodule EpochtalkServer.Models.BannedAddress do
   @one_week_in_ms 1000 * 60 * 60 * 24 * 7
   @inital_amount 0.8897
   @rate_of_decay 0.9644
+  @ip32_weight 1
+  @ip24_weight 0.04
+  @ip16_weight 0.0016
 
   @moduledoc """
   `BannedAddress` model, for performing actions relating to banning by ip/hostname
@@ -230,7 +233,7 @@ defmodule EpochtalkServer.Models.BannedAddress do
         ip24_score = calculate_ip24_score(ip)
         ip16_score = calculate_ip16_score(ip)
         # calculate malicious score using all scores
-        malicious_score = hostname_score + ip32_score + 0.04 + ip24_score + 0.0016 + ip16_score
+        malicious_score = hostname_score + (@ip32_weight * ip32_score) + (@ip24_weight * ip24_score) + (@ip16_weight * ip16_score)
         if malicious_score < 1, do: nil, else: malicious_score
 
       # invalid ip address, return nil for malicious score

--- a/lib/epochtalk_server/models/banned_address.ex
+++ b/lib/epochtalk_server/models/banned_address.ex
@@ -233,7 +233,10 @@ defmodule EpochtalkServer.Models.BannedAddress do
         ip24_score = calculate_ip24_score(ip)
         ip16_score = calculate_ip16_score(ip)
         # calculate malicious score using all scores
-        malicious_score = hostname_score + (@ip32_weight * ip32_score) + (@ip24_weight * ip24_score) + (@ip16_weight * ip16_score)
+        malicious_score =
+          hostname_score + @ip32_weight * ip32_score + @ip24_weight * ip24_score +
+            @ip16_weight * ip16_score
+
         if malicious_score < 1, do: nil, else: malicious_score
 
       # invalid ip address, return nil for malicious score
@@ -318,7 +321,9 @@ defmodule EpochtalkServer.Models.BannedAddress do
   defp decay_for_time(time, weight) do
     weight = Decimal.to_float(weight)
     weeks = time / @one_week_in_ms
-    @inital_amount ** ((@rate_of_decay ** weeks - 1) / (@rate_of_decay - 1)) * weight ** (@rate_of_decay ** weeks)
+
+    @inital_amount ** ((@rate_of_decay ** weeks - 1) / (@rate_of_decay - 1)) *
+      weight ** (@rate_of_decay ** weeks)
   end
 
   # returns the decayed score given a banned address

--- a/lib/epochtalk_server/models/banned_address.ex
+++ b/lib/epochtalk_server/models/banned_address.ex
@@ -229,13 +229,12 @@ defmodule EpochtalkServer.Models.BannedAddress do
               0
           end
 
-        ip32_score = calculate_ip32_score(ip)
-        ip24_score = calculate_ip24_score(ip)
-        ip16_score = calculate_ip16_score(ip)
+        # calculate ip scores with weight constants
+        ip32_score = calculate_ip32_score(ip) * @ip32_weight
+        ip24_score = calculate_ip24_score(ip) * @ip24_weight
+        ip16_score = calculate_ip16_score(ip) * @ip16_weight
         # calculate malicious score using all scores
-        malicious_score =
-          hostname_score + @ip32_weight * ip32_score + @ip24_weight * ip24_score +
-            @ip16_weight * ip16_score
+        malicious_score = hostname_score + ip32_score + ip24_score + ip16_score
 
         if malicious_score < 1, do: nil, else: malicious_score
 

--- a/lib/epochtalk_server/models/banned_address.ex
+++ b/lib/epochtalk_server/models/banned_address.ex
@@ -6,6 +6,10 @@ defmodule EpochtalkServer.Models.BannedAddress do
   alias EpochtalkServer.Repo
   alias EpochtalkServer.Models.BannedAddress
 
+  @one_week_in_ms 1000 * 60 * 60 * 24 * 7
+  @inital_amount 0.8897
+  @rate_of_decay 0.9644
+
   @moduledoc """
   `BannedAddress` model, for performing actions relating to banning by ip/hostname
   """
@@ -310,11 +314,8 @@ defmodule EpochtalkServer.Models.BannedAddress do
   # in ms since the weight was last updated
   defp decay_for_time(time, weight) do
     weight = Decimal.to_float(weight)
-    one_week = 1000 * 60 * 60 * 24 * 7
-    weeks = time / one_week
-    a = 0.8897
-    r = 0.9644
-    a ** ((r ** weeks - 1) / (r - 1)) * weight ** (r ** weeks)
+    weeks = time / @one_week_in_ms
+    @inital_amount ** ((@rate_of_decay ** weeks - 1) / (@rate_of_decay - 1)) * weight ** (@rate_of_decay ** weeks)
   end
 
   # returns the decayed score given a banned address

--- a/lib/epochtalk_server/models/board_moderator.ex
+++ b/lib/epochtalk_server/models/board_moderator.ex
@@ -60,7 +60,7 @@ defmodule EpochtalkServer.Models.BoardModerator do
     do: Repo.all(from(b in BoardModerator, select: b.board_id, where: b.user_id == ^user_id))
 
   @doc """
-  Check if a specific `User` is moderater of a `Board` using a `Board` ID
+  Check if a specific `User` is moderator of a `Board` using a `Board` ID
   """
   @spec user_is_moderator(
           board_id :: non_neg_integer,
@@ -77,7 +77,7 @@ defmodule EpochtalkServer.Models.BoardModerator do
   end
 
   @doc """
-  Check if a specific `User` is moderater of a `Board` using a `Thread` ID
+  Check if a specific `User` is moderator of a `Board` using a `Thread` ID
   """
   @spec user_is_moderator_with_thread_id(thread_id :: non_neg_integer, user_id :: non_neg_integer) ::
           boolean
@@ -95,7 +95,7 @@ defmodule EpochtalkServer.Models.BoardModerator do
   end
 
   @doc """
-  Check if a specific `User` is moderater of a `Board` using a `Post` ID
+  Check if a specific `User` is moderator of a `Board` using a `Post` ID
   """
   @spec user_is_moderator_with_post_id(
           post_id :: non_neg_integer,

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -154,6 +154,18 @@ defmodule EpochtalkServer.Session do
     Redix.command(:redix, ["ZRANGE", session_key, 0, -1])
   end
 
+  defp has_sessions?(user_id) do
+    session_key = generate_key(user_id, "sessions")
+    # check ZCARD for key
+    # returns number of sorted set elements at key
+    # returns 0 if key does not exist (set is empty)
+    case Redix.command(:redix, ["ZCARD", session_key]) do
+      {:error, error} -> {:error, error}
+      {:ok, 0} -> false
+      {:ok, _score} -> true
+    end
+  end
+
   defp is_active_for_user_id?(session_id, user_id) do
     session_key = generate_key(user_id, "sessions")
     # check ZSCORE for user_id:session_id pair

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -132,10 +132,11 @@ defmodule EpochtalkServer.Session do
             do: Map.put(resource, :ban_expiration, ban_expiration),
             else: resource
 
-        malicious_score = Redix.command!(:redix, ["HEXISTS", ban_key, "malicious_score"])
+        malicious_score_exists = Redix.command!(:redix, ["HEXISTS", ban_key, "malicious_score"])
+        malicious_score = Redix.command!(:redix, ["HGET", ban_key, "malicious_score"])
 
         resource =
-          if malicious_score != 0,
+          if malicious_score_exists != 0,
             do: Map.put(resource, :malicious_score, malicious_score),
             else: resource
 

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -5,6 +5,7 @@ defmodule EpochtalkServer.Session do
   @moduledoc """
   Manages `User` sessions in Redis. Used by Auth related `User` actions.
   """
+  require Logger
   alias EpochtalkServer.Auth.Guardian
   alias EpochtalkServer.Models.User
   alias EpochtalkServer.Models.Role
@@ -378,6 +379,10 @@ defmodule EpochtalkServer.Session do
         Redix.command(:redix, ["EXPIRE", key, new_ttl, "NX"])
       true ->
         # catch-all, in case both given expiries are invalid
+        Logger.warning("Invalid TTL's, setting max expiry", %{
+          module: __MODULE__,
+          parameters: "[old_ttl: #{old_ttl}, new_ttl: #{new_ttl}, key: #{key}]"
+        })
         # if neither expiry is valid, set ttl to max
         Redix.command(:redix, ["EXPIRE", key, @four_weeks_in_seconds])
     end

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -80,7 +80,7 @@ defmodule EpochtalkServer.Session do
           | {:error, reason :: String.t() | Redix.Error.t() | Redix.ConnectionError.t()}
   def get_resource(user_id, session_id) do
     # check if session is active in redis
-    is_active_for_user_id(session_id, user_id)
+    is_active_for_user_id?(session_id, user_id)
     |> case do
       {:error, error} ->
         {:error, "Error finding resource from claims #{inspect(error)}"}
@@ -146,7 +146,7 @@ defmodule EpochtalkServer.Session do
     Redix.command(:redix, ["ZRANGE", session_key, 0, -1])
   end
 
-  defp is_active_for_user_id(session_id, user_id) do
+  defp is_active_for_user_id?(session_id, user_id) do
     session_key = generate_key(user_id, "sessions")
     # check ZSCORE for user_id:session_id pair
     # returns score if it is a member of the set

--- a/lib/epochtalk_server/session.ex
+++ b/lib/epochtalk_server/session.ex
@@ -124,10 +124,11 @@ defmodule EpochtalkServer.Session do
             else: resource
 
         ban_key = generate_key(user_id, "baninfo")
-        ban_expiration = Redix.command!(:redix, ["HEXISTS", ban_key, "ban_expiration"])
+        ban_expiration_exists = Redix.command!(:redix, ["HEXISTS", ban_key, "ban_expiration"])
+        ban_expiration = Redix.command!(:redix, ["HGET", ban_key, "ban_expiration"])
 
         resource =
-          if ban_expiration != 0,
+          if ban_expiration_exists != 0,
             do: Map.put(resource, :ban_expiration, ban_expiration),
             else: resource
 

--- a/test/epochtalk_server/models/profile_test.exs
+++ b/test/epochtalk_server/models/profile_test.exs
@@ -1,7 +1,16 @@
 defmodule Test.EpochtalkServer.Models.Profile do
   use Test.Support.DataCase, async: true
   alias EpochtalkServer.Models.Profile
+  alias EpochtalkServer.Models.User
 
+  describe "upsert/2" do
+    test "given valid user_id, updates user's avatar", %{users: %{user: user}} do
+      assert user.profile.avatar == ""
+      Profile.upsert(user.id, %{avatar: "image.png"})
+      {:ok, updated_user} = User.by_id(user.id)
+      assert updated_user.profile.avatar == "image.png"
+    end
+  end
   describe "create/2" do
     test "given invalid user_id, errors with Ecto.ConstraintError" do
       invalid_user_id = 0

--- a/test/epochtalk_server/models/profile_test.exs
+++ b/test/epochtalk_server/models/profile_test.exs
@@ -1,0 +1,15 @@
+defmodule Test.EpochtalkServer.Models.Profile do
+  use Test.Support.DataCase, async: true
+  alias EpochtalkServer.Models.Profile
+
+  describe "create/2" do
+    test "given invalid user_id, errors with Ecto.ConstraintError" do
+      invalid_user_id = 0
+      assert_raise Ecto.ConstraintError,
+                   ~r/profiles_user_id_fkey/,
+                   fn ->
+                     Profile.create(invalid_user_id)
+                   end
+    end
+  end
+end

--- a/test/epochtalk_server/models/profile_test.exs
+++ b/test/epochtalk_server/models/profile_test.exs
@@ -11,5 +11,12 @@ defmodule Test.EpochtalkServer.Models.Profile do
                      Profile.create(invalid_user_id)
                    end
     end
+    test "given an existing user_id, errors with Ecto.ConstraintError", %{users: %{user: user}} do
+      assert_raise Ecto.ConstraintError,
+                   ~r/profiles_user_id_index/,
+                   fn ->
+                     Profile.create(user.id)
+                   end
+    end
   end
 end

--- a/test/epochtalk_server/models/profile_test.exs
+++ b/test/epochtalk_server/models/profile_test.exs
@@ -20,6 +20,7 @@ defmodule Test.EpochtalkServer.Models.Profile do
         signature: "signature",
         raw_signature: "raw_signature"
       }
+
       Profile.upsert(user.id, updated_attrs)
       {:ok, updated_user} = User.by_id(user.id)
       assert updated_user.profile.avatar == updated_attrs.avatar
@@ -28,15 +29,18 @@ defmodule Test.EpochtalkServer.Models.Profile do
       assert updated_user.profile.raw_signature == updated_attrs.raw_signature
     end
   end
+
   describe "create/2" do
     test "given invalid user_id, errors with Ecto.ConstraintError" do
       invalid_user_id = 0
+
       assert_raise Ecto.ConstraintError,
                    ~r/profiles_user_id_fkey/,
                    fn ->
                      Profile.create(invalid_user_id)
                    end
     end
+
     test "given an existing user_id, errors with Ecto.ConstraintError", %{users: %{user: user}} do
       assert_raise Ecto.ConstraintError,
                    ~r/profiles_user_id_index/,

--- a/test/epochtalk_server/models/profile_test.exs
+++ b/test/epochtalk_server/models/profile_test.exs
@@ -4,7 +4,7 @@ defmodule Test.EpochtalkServer.Models.Profile do
   alias EpochtalkServer.Models.User
 
   describe "upsert/2" do
-    test "given valid user_id, updates user's avatar", %{users: %{user: user}} do
+    test "given valid user_id, updates user's profile", %{users: %{user: user}} do
       # check default fields
       assert user.profile.avatar == ""
       assert user.profile.position == nil
@@ -14,9 +14,18 @@ defmodule Test.EpochtalkServer.Models.Profile do
       assert user.profile.raw_signature == nil
       assert user.profile.last_active == nil
 
-      Profile.upsert(user.id, %{avatar: "image.png"})
+      updated_attrs = %{
+        avatar: "image.png",
+        position: "position",
+        signature: "signature",
+        raw_signature: "raw_signature"
+      }
+      Profile.upsert(user.id, updated_attrs)
       {:ok, updated_user} = User.by_id(user.id)
-      assert updated_user.profile.avatar == "image.png"
+      assert updated_user.profile.avatar == updated_attrs.avatar
+      assert updated_user.profile.position == updated_attrs.position
+      assert updated_user.profile.signature == updated_attrs.signature
+      assert updated_user.profile.raw_signature == updated_attrs.raw_signature
     end
   end
   describe "create/2" do

--- a/test/epochtalk_server/models/profile_test.exs
+++ b/test/epochtalk_server/models/profile_test.exs
@@ -5,7 +5,15 @@ defmodule Test.EpochtalkServer.Models.Profile do
 
   describe "upsert/2" do
     test "given valid user_id, updates user's avatar", %{users: %{user: user}} do
+      # check default fields
       assert user.profile.avatar == ""
+      assert user.profile.position == nil
+      assert user.profile.signature == nil
+      assert user.profile.post_count == 0
+      assert user.profile.fields == nil
+      assert user.profile.raw_signature == nil
+      assert user.profile.last_active == nil
+
       Profile.upsert(user.id, %{avatar: "image.png"})
       {:ok, updated_user} = User.by_id(user.id)
       assert updated_user.profile.avatar == "image.png"

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -409,7 +409,7 @@ defmodule Test.EpochtalkServer.Session do
     end
 
     @tag :authenticated
-    test "given a not banned user's id, when user is banned, updates role to add ban info", %{conn: conn, authed_user: authed_user} do
+    test "given a not banned user's id, when user is banned, adds banned role", %{conn: conn, authed_user: authed_user} do
       # get session_id (jti) from conn
       session_id = conn.private.guardian_default_claims["jti"]
       # check that session user does not have banned role
@@ -425,7 +425,7 @@ defmodule Test.EpochtalkServer.Session do
       assert Enum.any?(banned_resource_user.roles, &(&1.lookup == "banned")) == true
     end
     @tag [authenticated: true, banned: true]
-    test "given a banned user's id, when user is unbanned, updates role to delete ban info", %{conn: conn, authed_user: authed_user} do
+    test "given a banned user's id, when user is unbanned, deletes banned role", %{conn: conn, authed_user: authed_user} do
       # get session_id (jti) from conn
       session_id = conn.private.guardian_default_claims["jti"]
       # check that session user has banned role

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -10,6 +10,7 @@ defmodule Test.EpochtalkServer.Session do
   @almost_four_weeks_in_seconds @four_weeks_in_seconds - 100
   alias EpochtalkServer.Session
   alias EpochtalkServer.Models.Profile
+  alias EpochtalkServer.Models.RoleUser
 
   describe "get_resource/2" do
     test "when session_id is invalid, errors", %{users: %{user: user}} do
@@ -377,6 +378,18 @@ defmodule Test.EpochtalkServer.Session do
       session_id = conn.private.guardian_default_claims["jti"]
       {:ok, resource_user} = Session.get_resource(authed_user.id, session_id)
       assert resource_user.avatar == updated_attrs.avatar
+    end
+    @tag :authenticated
+    test "given a valid user id, updates role to admin", %{conn: conn, authed_user: authed_user} do
+      authed_user_role = List.first(authed_user.roles)
+      assert authed_user_role.lookup == "user"
+      RoleUser.set_admin(authed_user.id)
+      Session.update(authed_user.id)
+      # get session_id (jti) from conn
+      session_id = conn.private.guardian_default_claims["jti"]
+      {:ok, resource_user} = Session.get_resource(authed_user.id, session_id)
+      resource_user_role = List.first(resource_user.roles)
+      assert resource_user_role.lookup == "superAdministrator"
     end
   end
 

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -458,6 +458,10 @@ defmodule Test.EpochtalkServer.Session do
       Session.update(authed_user.id)
       {:ok, unbanned_resource_user} = Session.get_resource(authed_user.id, session_id)
       assert Enum.any?(unbanned_resource_user.roles, &(&1.lookup == "banned")) == false
+      # check ban is expired
+      now = NaiveDateTime.utc_now()
+      {:ok, ban_expiration} = unbanned_resource_user.ban_expiration |> NaiveDateTime.from_iso8601()
+      assert NaiveDateTime.compare(ban_expiration, now) == :lt
     end
   end
 

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -360,6 +360,15 @@ defmodule Test.EpochtalkServer.Session do
     end
   end
 
+  describe "update/1" do
+    test "given invalid user id, errors with :user_not_found", %{conn: conn} do
+      assert Session.update(0) == {:error, :user_not_found}
+    end
+    test "given user id without sessions, errors with :no_sessions", %{conn: conn, users: %{no_login_user: user}} do
+      assert Session.update(user.id) == {:error, :no_sessions}
+    end
+  end
+
   defp flush_redis(_) do
     Redix.command!(:redix, ["FLUSHALL"])
     :ok

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -333,7 +333,7 @@ defmodule Test.EpochtalkServer.Session do
         Redix.command!(:redix, ["HGET", "user:#{authed_user.id}:baninfo", "malicious_score"])
 
       assert pre_malicious_malicious_score == nil
-      assert malicious_score == "4.0416"
+      assert malicious_score == "2.0416"
       assert pre_malicious_baninfo_ttl == -2
       assert malicious_score_ttl <= @one_day_in_seconds
       assert malicious_score_ttl > @almost_one_day_in_seconds
@@ -360,7 +360,7 @@ defmodule Test.EpochtalkServer.Session do
         Redix.command!(:redix, ["HGET", "user:#{authed_user.id}:baninfo", "malicious_score"])
 
       assert pre_malicious_malicious_score == nil
-      assert malicious_score == "4.0416"
+      assert malicious_score == "2.0416"
       assert pre_malicious_baninfo_ttl == -2
       assert malicious_score_ttl <= @four_weeks_in_seconds
       assert malicious_score_ttl > @almost_four_weeks_in_seconds

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -368,9 +368,14 @@ defmodule Test.EpochtalkServer.Session do
     test "given invalid user id, errors with :user_not_found", %{conn: conn} do
       assert Session.update(0) == {:error, :user_not_found}
     end
-    test "given user id without sessions, errors with :no_sessions", %{conn: conn, users: %{no_login_user: user}} do
+
+    test "given user id without sessions, errors with :no_sessions", %{
+      conn: conn,
+      users: %{no_login_user: user}
+    } do
       assert Session.update(user.id) == {:error, :no_sessions}
     end
+
     @tag :authenticated
     test "given a valid user id, updates avatar", %{conn: conn, authed_user: authed_user} do
       updated_attrs = %{avatar: "image.png"}
@@ -381,6 +386,7 @@ defmodule Test.EpochtalkServer.Session do
       {:ok, resource_user} = Session.get_resource(authed_user.id, session_id)
       assert resource_user.avatar == updated_attrs.avatar
     end
+
     @tag :authenticated
     test "given a valid user id, updates role to admin", %{conn: conn, authed_user: authed_user} do
       authed_user_role = List.first(authed_user.roles)
@@ -393,8 +399,12 @@ defmodule Test.EpochtalkServer.Session do
       resource_user_role = List.first(resource_user.roles)
       assert resource_user_role == RoleCache.by_lookup("superAdministrator")
     end
+
     @tag authenticated: :super_admin
-    test "given a valid superAdministrator id, updates role to delete admin + add user", %{conn: conn, authed_user: authed_user} do
+    test "given a valid superAdministrator id, updates role to delete admin + add user", %{
+      conn: conn,
+      authed_user: authed_user
+    } do
       authed_user_role = List.first(authed_user.roles)
       super_administrator_role = RoleCache.by_lookup("superAdministrator")
       assert authed_user_role == super_administrator_role
@@ -409,7 +419,10 @@ defmodule Test.EpochtalkServer.Session do
     end
 
     @tag :authenticated
-    test "given a not banned user's id, when user is banned, adds banned role", %{conn: conn, authed_user: authed_user} do
+    test "given a not banned user's id, when user is banned, adds banned role", %{
+      conn: conn,
+      authed_user: authed_user
+    } do
       # get session_id (jti) from conn
       session_id = conn.private.guardian_default_claims["jti"]
       # check that session user does not have banned role
@@ -424,8 +437,12 @@ defmodule Test.EpochtalkServer.Session do
       {:ok, banned_resource_user} = Session.get_resource(authed_user.id, session_id)
       assert Enum.any?(banned_resource_user.roles, &(&1.lookup == "banned")) == true
     end
+
     @tag [authenticated: true, banned: true]
-    test "given a banned user's id, when user is unbanned, deletes banned role", %{conn: conn, authed_user: authed_user} do
+    test "given a banned user's id, when user is unbanned, deletes banned role", %{
+      conn: conn,
+      authed_user: authed_user
+    } do
       # get session_id (jti) from conn
       session_id = conn.private.guardian_default_claims["jti"]
       # check that session user has banned role

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -8,6 +8,7 @@ defmodule Test.EpochtalkServer.Session do
   @almost_one_day_in_seconds @one_day_in_seconds - 100
   @four_weeks_in_seconds 4 * 7 * @one_day_in_seconds
   @almost_four_weeks_in_seconds @four_weeks_in_seconds - 100
+  @max_date "9999-12-31 00:00:00"
   alias EpochtalkServer.Session
   alias EpochtalkServer.Models.Profile
   alias EpochtalkServer.Models.RoleUser
@@ -271,7 +272,7 @@ defmodule Test.EpochtalkServer.Session do
         Redix.command!(:redix, ["HGET", "user:#{user.id}:baninfo", "ban_expiration"])
 
       assert pre_ban_ban_expiration == nil
-      assert ban_expiration == "9999-12-31 00:00:00"
+      assert ban_expiration == @max_date
       assert pre_ban_baninfo_ttl == -2
       assert baninfo_ttl <= @one_day_in_seconds
       assert baninfo_ttl > @almost_one_day_in_seconds
@@ -303,7 +304,7 @@ defmodule Test.EpochtalkServer.Session do
         Redix.command!(:redix, ["HGET", "user:#{user.id}:baninfo", "ban_expiration"])
 
       assert pre_ban_ban_expiration == nil
-      assert ban_expiration == "9999-12-31 00:00:00"
+      assert ban_expiration == @max_date
       assert pre_ban_baninfo_ttl == -2
       assert baninfo_ttl <= @four_weeks_in_seconds
       assert baninfo_ttl > @almost_four_weeks_in_seconds

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -393,16 +393,17 @@ defmodule Test.EpochtalkServer.Session do
       assert resource_user_role == RoleCache.by_lookup("superAdministrator")
     end
     @tag authenticated: :super_admin
-    test "given a valid superAdministrator id, updates role to user", %{conn: conn, authed_user: authed_user} do
+    test "given a valid superAdministrator id, updates role to delete admin + add user", %{conn: conn, authed_user: authed_user} do
       authed_user_role = List.first(authed_user.roles)
-      assert authed_user_role == RoleCache.by_lookup("superAdministrator")
-      user_role = RoleCache.by_lookup("user")
-      RoleUser.set_user_role(user_role.id, authed_user.id)
+      super_administrator_role = RoleCache.by_lookup("superAdministrator")
+      assert authed_user_role == super_administrator_role
+      RoleUser.delete(super_administrator_role.id, authed_user.id)
       Session.update(authed_user.id)
       # get session_id (jti) from conn
       session_id = conn.private.guardian_default_claims["jti"]
       {:ok, resource_user} = Session.get_resource(authed_user.id, session_id)
       resource_user_role = List.first(resource_user.roles)
+      user_role = RoleCache.by_lookup("user")
       assert resource_user_role == user_role
     end
   end

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -365,12 +365,11 @@ defmodule Test.EpochtalkServer.Session do
   end
 
   describe "update/1" do
-    test "given invalid user id, errors with :user_not_found", %{conn: conn} do
+    test "given invalid user id, errors with :user_not_found" do
       assert Session.update(0) == {:error, :user_not_found}
     end
 
     test "given user id without sessions, errors with :no_sessions", %{
-      conn: conn,
       users: %{no_login_user: user}
     } do
       assert Session.update(user.id) == {:error, :no_sessions}

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -436,6 +436,8 @@ defmodule Test.EpochtalkServer.Session do
       Session.update(authed_user.id)
       {:ok, banned_resource_user} = Session.get_resource(authed_user.id, session_id)
       assert Enum.any?(banned_resource_user.roles, &(&1.lookup == "banned")) == true
+      # check ban is active
+      assert banned_resource_user.ban_expiration == @max_date
     end
 
     @tag [authenticated: true, banned: true]

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -429,7 +429,6 @@ defmodule Test.EpochtalkServer.Session do
       # get session_id (jti) from conn
       session_id = conn.private.guardian_default_claims["jti"]
       # check that session user has banned role
-      Session.update(authed_user.id)
       {:ok, banned_resource_user} = Session.get_resource(authed_user.id, session_id)
       assert Enum.any?(banned_resource_user.roles, &(&1.lookup == "banned")) == true
 

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -11,6 +11,7 @@ defmodule Test.EpochtalkServer.Session do
   alias EpochtalkServer.Session
   alias EpochtalkServer.Models.Profile
   alias EpochtalkServer.Models.RoleUser
+  alias EpochtalkServer.Cache.Role, as: RoleCache
 
   describe "get_resource/2" do
     test "when session_id is invalid, errors", %{users: %{user: user}} do
@@ -382,14 +383,14 @@ defmodule Test.EpochtalkServer.Session do
     @tag :authenticated
     test "given a valid user id, updates role to admin", %{conn: conn, authed_user: authed_user} do
       authed_user_role = List.first(authed_user.roles)
-      assert authed_user_role.lookup == "user"
+      assert authed_user_role == RoleCache.by_lookup("user")
       RoleUser.set_admin(authed_user.id)
       Session.update(authed_user.id)
       # get session_id (jti) from conn
       session_id = conn.private.guardian_default_claims["jti"]
       {:ok, resource_user} = Session.get_resource(authed_user.id, session_id)
       resource_user_role = List.first(resource_user.roles)
-      assert resource_user_role.lookup == "superAdministrator"
+      assert resource_user_role == RoleCache.by_lookup("superAdministrator")
     end
   end
 

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -467,15 +467,19 @@ defmodule Test.EpochtalkServer.Session do
       assert Enum.any?(unbanned_resource_user.roles, &(&1.lookup == "banned")) == false
       # check ban is expired
       now = NaiveDateTime.utc_now()
-      {:ok, ban_expiration} = unbanned_resource_user.ban_expiration |> NaiveDateTime.from_iso8601()
+
+      {:ok, ban_expiration} =
+        unbanned_resource_user.ban_expiration |> NaiveDateTime.from_iso8601()
+
       assert NaiveDateTime.compare(ban_expiration, now) == :lt
     end
 
     @tag :authenticated
-    test "given a not malicious user's id, when user is marked malicious, adds malicious score", %{
-      conn: conn,
-      authed_user: authed_user
-    } do
+    test "given a not malicious user's id, when user is marked malicious, adds malicious score",
+         %{
+           conn: conn,
+           authed_user: authed_user
+         } do
       # get session_id (jti) from conn
       session_id = conn.private.guardian_default_claims["jti"]
       # check that session user does not have banned role
@@ -500,6 +504,7 @@ defmodule Test.EpochtalkServer.Session do
       assert malicious_resource_user.ban_expiration == @max_date
     end
   end
+
   describe "update/1 moderating" do
     @tag :authenticated
     test "when a user is added/removed as moderator, updates moderating", %{

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -392,6 +392,19 @@ defmodule Test.EpochtalkServer.Session do
       resource_user_role = List.first(resource_user.roles)
       assert resource_user_role == RoleCache.by_lookup("superAdministrator")
     end
+    @tag authenticated: :super_admin
+    test "given a valid superAdministrator id, updates role to user", %{conn: conn, authed_user: authed_user} do
+      authed_user_role = List.first(authed_user.roles)
+      assert authed_user_role == RoleCache.by_lookup("superAdministrator")
+      user_role = RoleCache.by_lookup("user")
+      RoleUser.set_user_role(user_role.id, authed_user.id)
+      Session.update(authed_user.id)
+      # get session_id (jti) from conn
+      session_id = conn.private.guardian_default_claims["jti"]
+      {:ok, resource_user} = Session.get_resource(authed_user.id, session_id)
+      resource_user_role = List.first(resource_user.roles)
+      assert resource_user_role == user_role
+    end
   end
 
   defp flush_redis(_) do

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -476,6 +476,7 @@ defmodule Test.EpochtalkServer.Session do
       # check that session user does not have banned role
       {:ok, resource_user} = Session.get_resource(authed_user.id, session_id)
       assert Enum.any?(resource_user.roles, &(&1.lookup == "banned")) == false
+      # check user does not have malicious score or ban expiration
       assert Map.get(resource_user, :malicious_score) == nil
       assert Map.get(resource_user, :ban_expiration) == nil
 
@@ -488,10 +489,11 @@ defmodule Test.EpochtalkServer.Session do
       Session.update(authed_user.id)
       {:ok, malicious_resource_user} = Session.get_resource(authed_user.id, session_id)
       assert Enum.any?(malicious_resource_user.roles, &(&1.lookup == "banned")) == true
-      # check ban is active
-      assert malicious_resource_user.ban_expiration == @max_date
-      # check malicious score is active
+      # check malicious score and ban are active
       assert malicious_resource_user.malicious_score != nil
+      assert malicious_resource_user.malicious_score > 1
+      assert malicious_resource_user.ban_expiration == @max_date
+    end
     end
   end
 

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -388,7 +388,9 @@ defmodule Test.EpochtalkServer.Session do
       {:ok, resource_user} = Session.get_resource(authed_user.id, session_id)
       assert resource_user.avatar == updated_attrs.avatar
     end
+  end
 
+  describe "update/1 role" do
     @tag :authenticated
     test "given a valid user id, updates role to admin", %{conn: conn, authed_user: authed_user} do
       authed_user_role = List.first(authed_user.roles)
@@ -419,7 +421,9 @@ defmodule Test.EpochtalkServer.Session do
       user_role = RoleCache.by_lookup("user")
       assert resource_user_role == user_role
     end
+  end
 
+  describe "update/1 baninfo" do
     @tag :authenticated
     test "given a not banned user's id, when user is banned, adds banned role", %{
       conn: conn,

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -16,6 +16,7 @@ defmodule Test.EpochtalkServer.Session do
   alias EpochtalkServer.Models.RoleUser
   alias EpochtalkServer.Cache.Role, as: RoleCache
   alias EpochtalkServer.Models.Ban
+  alias EpochtalkServer.Models.BoardModerator
 
   describe "get_resource/2" do
     test "when session_id is invalid, errors", %{users: %{user: user}} do
@@ -498,6 +499,37 @@ defmodule Test.EpochtalkServer.Session do
       assert malicious_resource_user.malicious_score > 1
       assert malicious_resource_user.ban_expiration == @max_date
     end
+  end
+  describe "update/1 moderating" do
+    @tag :authenticated
+    test "when a user is added/removed as moderator, updates moderating", %{
+      conn: conn,
+      authed_user: authed_user
+    } do
+      # get session_id (jti) from conn
+      session_id = conn.private.guardian_default_claims["jti"]
+      # check that session user's moderating list is empty
+      {:ok, resource_user} = Session.get_resource(authed_user.id, session_id)
+      assert Map.get(resource_user, :moderating) == nil
+
+      # create board and add user as moderator
+      board = insert(:board)
+      BoardModerator.add_moderators_by_username(board.id, [authed_user.username])
+
+      # check session user updates with moderating
+      Session.update(authed_user.id)
+      {:ok, moderator_resource_user} = Session.get_resource(authed_user.id, session_id)
+      # check moderating list contains new board
+      assert Map.get(moderator_resource_user, :moderating) == [Integer.to_string(board.id)]
+
+      # remove user as moderator
+      BoardModerator.remove_moderators_by_username(board.id, [authed_user.username])
+
+      # check session user updates with moderating
+      Session.update(authed_user.id)
+      {:ok, moderator_resource_user} = Session.get_resource(authed_user.id, session_id)
+      # check moderating list contains new board
+      assert Map.get(moderator_resource_user, :moderating) == nil
     end
   end
 

--- a/test/epochtalk_server_web/controllers/user_test.exs
+++ b/test/epochtalk_server_web/controllers/user_test.exs
@@ -72,7 +72,7 @@ defmodule Test.EpochtalkServerWeb.Controllers.User do
     } do
       assert malicious_user_changeset.ban_info.user_id == user.id
       # check that ip and hostname were banned
-      assert malicious_user_changeset.malicious_score == 4.0416
+      assert malicious_user_changeset.malicious_score == 2.0416
     end
   end
 

--- a/test/seed/users.exs
+++ b/test/seed/users.exs
@@ -12,6 +12,10 @@ test_user_username = "user"
 test_user_email = "user@test.com"
 test_user_password = "password"
 
+test_no_login_user_username = "no_login"
+test_no_login_user_email = "no_login@test.com"
+test_no_login_user_password = "password"
+
 build(:user,
   username: test_super_admin_user_username,
   email: test_super_admin_user_email,
@@ -30,6 +34,12 @@ build(:user,
   username: test_user_username,
   email: test_user_email,
   password: test_user_password
+)
+
+build(:user,
+  username: test_no_login_user_username,
+  email: test_no_login_user_email,
+  password: test_no_login_user_password
 )
 
 IO.puts("Successfully seeded test users")

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -15,6 +15,16 @@ defmodule Test.Support.ConnCase do
   this option is not recommended for other databases.
   """
 
+  # no_login username/email/password from user seed in `mix test` (see mix.exs)
+  @test_no_login_username "no_login"
+  @test_no_login_email "no_login@test.com"
+  @test_no_login_password "password"
+  @test_no_login_user_attrs %{
+    username: @test_no_login_username,
+    email: @test_no_login_email,
+    password: @test_no_login_password
+  }
+
   # username/email/password from user seed in `mix test` (see mix.exs)
   @test_username "user"
   @test_email "user@test.com"
@@ -75,6 +85,7 @@ defmodule Test.Support.ConnCase do
       Ecto.Adapters.SQL.Sandbox.mode(EpochtalkServer.Repo, {:shared, self()})
     end
 
+    {:ok, no_login_user} = User.by_username(@test_no_login_username)
     {:ok, user} = User.by_username(@test_username)
     {:ok, admin_user} = User.by_username(@test_admin_username)
     {:ok, super_admin_user} = User.by_username(@test_super_admin_username)
@@ -84,11 +95,13 @@ defmodule Test.Support.ConnCase do
       {:ok,
        [
          users: %{
+           no_login_user: no_login_user,
            user: user,
            admin_user: admin_user,
            super_admin_user: super_admin_user
          },
          user_attrs: %{
+           no_login_user: @test_no_login_user_attrs,
            user: @test_user_attrs,
            admin_user: @test_admin_user_attrs,
            super_admin_user: @test_super_admin_user_attrs

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -157,6 +157,8 @@ defmodule Test.Support.ConnCase do
     context_updates =
       if context[:banned] do
         {:ok, banned_user_changeset} = Ban.ban(user)
+        # update ban info in session
+        Session.update(user.id)
         {:ok, k_list} = context_updates
         {:ok, [banned_user_changeset: banned_user_changeset] ++ k_list}
       else

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -74,22 +74,23 @@ defmodule Test.Support.DataCase do
     {:ok, user} = User.by_username(@test_username)
     {:ok, admin_user} = User.by_username(@test_admin_username)
     {:ok, super_admin_user} = User.by_username(@test_super_admin_username)
+
     {
       :ok,
-       [
-         users: %{
-           no_login_user: no_login_user,
-           user: user,
-           admin_user: admin_user,
-           super_admin_user: super_admin_user
-         },
-         user_attrs: %{
-           no_login_user: @test_no_login_user_attrs,
-           user: @test_user_attrs,
-           admin_user: @test_admin_user_attrs,
-           super_admin_user: @test_super_admin_user_attrs
-         }
-       ]
+      [
+        users: %{
+          no_login_user: no_login_user,
+          user: user,
+          admin_user: admin_user,
+          super_admin_user: super_admin_user
+        },
+        user_attrs: %{
+          no_login_user: @test_no_login_user_attrs,
+          user: @test_user_attrs,
+          admin_user: @test_admin_user_attrs,
+          super_admin_user: @test_super_admin_user_attrs
+        }
+      ]
     }
   end
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -14,6 +14,46 @@ defmodule Test.Support.DataCase do
   this option is not recommended for other databases.
   """
 
+  # no_login username/email/password from user seed in `mix test` (see mix.exs)
+  @test_no_login_username "no_login"
+  @test_no_login_email "no_login@test.com"
+  @test_no_login_password "password"
+  @test_no_login_user_attrs %{
+    username: @test_no_login_username,
+    email: @test_no_login_email,
+    password: @test_no_login_password
+  }
+
+  # username/email/password from user seed in `mix test` (see mix.exs)
+  @test_username "user"
+  @test_email "user@test.com"
+  @test_password "password"
+  @test_user_attrs %{
+    username: @test_username,
+    email: @test_email,
+    password: @test_password
+  }
+
+  # admin username/email/password from user seed in `mix test` (see mix.exs)
+  @test_admin_username "admin"
+  @test_admin_email "admin@test.com"
+  @test_admin_password "password"
+  @test_admin_user_attrs %{
+    username: @test_admin_username,
+    email: @test_admin_email,
+    password: @test_admin_password
+  }
+
+  # super admin username/email/password from user seed in `mix test` (see mix.exs)
+  @test_super_admin_username "superadmin"
+  @test_super_admin_email "superadmin@test.com"
+  @test_super_admin_password "password"
+  @test_super_admin_user_attrs %{
+    username: @test_super_admin_username,
+    email: @test_super_admin_email,
+    password: @test_super_admin_password
+  }
+
   use ExUnit.CaseTemplate
 
   using do
@@ -28,8 +68,29 @@ defmodule Test.Support.DataCase do
   end
 
   setup tags do
+    alias EpochtalkServer.Models.User
     Test.Support.DataCase.setup_sandbox(tags)
-    :ok
+    {:ok, no_login_user} = User.by_username(@test_no_login_username)
+    {:ok, user} = User.by_username(@test_username)
+    {:ok, admin_user} = User.by_username(@test_admin_username)
+    {:ok, super_admin_user} = User.by_username(@test_super_admin_username)
+    {
+      :ok,
+       [
+         users: %{
+           no_login_user: no_login_user,
+           user: user,
+           admin_user: admin_user,
+           super_admin_user: super_admin_user
+         },
+         user_attrs: %{
+           no_login_user: @test_no_login_user_attrs,
+           user: @test_user_attrs,
+           admin_user: @test_admin_user_attrs,
+           super_admin_user: @test_super_admin_user_attrs
+         }
+       ]
+    }
   end
 
   @doc """

--- a/test/support/factories/banned_address.ex
+++ b/test/support/factories/banned_address.ex
@@ -7,34 +7,11 @@ defmodule Test.Support.Factories.BannedAddress do
   OR
   build(:banned_address, hostname: hostname, weight: weight)
   """
-  alias EpochtalkServer.Repo
   alias EpochtalkServer.Models.BannedAddress
 
   defmacro __using__(_opts) do
     quote do
-      def banned_address_attributes_factory(%{ip: ip, weight: weight}) do
-        %{
-          ip: ip,
-          weight: weight,
-          created_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
-          imported_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
-        }
-      end
-
-      def banned_address_attributes_factory(%{hostname: hostname, weight: weight}) do
-        %{
-          hostname: hostname,
-          weight: weight,
-          created_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
-          imported_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
-        }
-      end
-
-      def banned_address_factory(attributes) do
-        %BannedAddress{}
-        |> BannedAddress.upsert_changeset(build(:banned_address_attributes, attributes))
-        |> Repo.insert()
-      end
+      def banned_address_factory(attributes), do: BannedAddress.upsert(attributes)
     end
   end
 end


### PR DESCRIPTION
major changes:

test session update changes
  refactor session update to use `with`
  store ban and malicious info in session instead of boolean values
  fix ttl issues, expiring on set

correct banned address calculation, refactor to extract magic numbers

implement profile test for upsert and create