### PR TITLE
fix(config/runtime): add issuer for guardian_config in :prod

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -117,6 +117,7 @@ guardian_config =
   case config_env() do
     :prod ->
       [
+        issuer: "EpochtalkServer",
         secret_key:
           get_env_or_raise_with_message.(
             "GUARDIAN_SECRET_KEY",


### PR DESCRIPTION
without this config, guardian redis completely breaks and it is ~~impossible~~ very difficult to trace where the issue came from

```
** (KeyError) key :wheres not found in: #Ecto.Changeset<action: nil,
changes: %{claims: %{"aud" => "" ...
```

the telltale issue here being the `"aud" => ""` rather than `t0.aud == ^"EpochtalkServer" ` like you would see if debugging a working instance