### PR TITLE
Fix move thread test refactor

### DIFF
--- a/lib/epochtalk_server/models/auto_moderation.ex
+++ b/lib/epochtalk_server/models/auto_moderation.ex
@@ -47,8 +47,8 @@ defmodule EpochtalkServer.Models.AutoModeration do
     field :conditions, {:array, :map}
     field :actions, {:array, :string}
     field :options, :map
-    field :created_at, :naive_datetime
-    field :updated_at, :naive_datetime
+    field :created_at, :naive_datetime_usec
+    field :updated_at, :naive_datetime_usec
   end
 
   ## === Changesets Functions ===
@@ -85,7 +85,7 @@ defmodule EpochtalkServer.Models.AutoModeration do
   """
   @spec update_changeset(auto_moderation :: t(), attrs :: map() | nil) :: Ecto.Changeset.t()
   def update_changeset(auto_moderation, attrs \\ %{}) do
-    updated_at = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    updated_at = NaiveDateTime.utc_now()
 
     auto_moderation =
       auto_moderation

--- a/lib/epochtalk_server/models/ban.ex
+++ b/lib/epochtalk_server/models/ban.ex
@@ -26,9 +26,9 @@ defmodule EpochtalkServer.Models.Ban do
   @derive {Jason.Encoder, only: [:user_id, :expiration, :created_at, :updated_at]}
   schema "bans" do
     belongs_to :user, User, primary_key: true
-    field :expiration, :naive_datetime
-    field :created_at, :naive_datetime
-    field :updated_at, :naive_datetime
+    field :expiration, :naive_datetime_usec
+    field :created_at, :naive_datetime_usec
+    field :updated_at, :naive_datetime_usec
   end
 
   ## === Changesets Functions ===
@@ -48,7 +48,7 @@ defmodule EpochtalkServer.Models.Ban do
   """
   @spec ban_changeset(ban :: t(), attrs :: map() | nil) :: Ecto.Changeset.t()
   def ban_changeset(ban, attrs \\ %{}) do
-    now = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    now = NaiveDateTime.utc_now()
 
     attrs =
       attrs
@@ -69,7 +69,7 @@ defmodule EpochtalkServer.Models.Ban do
   """
   @spec unban_changeset(ban :: t(), attrs :: map() | nil) :: Ecto.Changeset.t()
   def unban_changeset(ban, attrs \\ %{}) do
-    now = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    now = NaiveDateTime.utc_now()
 
     # set ban expiration to now when unbanning
     attrs =

--- a/lib/epochtalk_server/models/banned_address.ex
+++ b/lib/epochtalk_server/models/banned_address.ex
@@ -37,9 +37,9 @@ defmodule EpochtalkServer.Models.BannedAddress do
     field :ip4, :integer
     field :weight, :decimal
     field :decay, :boolean, default: false
-    field :imported_at, :naive_datetime
-    field :created_at, :naive_datetime
-    field :updates, {:array, :naive_datetime}
+    field :imported_at, :naive_datetime_usec
+    field :created_at, :naive_datetime_usec
+    field :updates, {:array, :naive_datetime_usec}
   end
 
   ## === Changesets Functions ===
@@ -49,7 +49,7 @@ defmodule EpochtalkServer.Models.BannedAddress do
   """
   @spec upsert_changeset(banned_address :: t(), attrs :: map() | nil) :: Ecto.Changeset.t()
   def upsert_changeset(banned_address, attrs \\ %{}) do
-    now = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    now = NaiveDateTime.utc_now()
 
     attrs =
       attrs

--- a/lib/epochtalk_server/models/board.ex
+++ b/lib/epochtalk_server/models/board.ex
@@ -51,9 +51,9 @@ defmodule EpochtalkServer.Models.Board do
     field :viewable_by, :integer
     field :postable_by, :integer
     field :right_to_left, :boolean, default: false
-    field :created_at, :naive_datetime
-    field :imported_at, :naive_datetime
-    field :updated_at, :naive_datetime
+    field :created_at, :naive_datetime_usec
+    field :imported_at, :naive_datetime_usec
+    field :updated_at, :naive_datetime_usec
     field :meta, :map
     many_to_many :category, Category, join_through: BoardMapping
   end
@@ -95,7 +95,7 @@ defmodule EpochtalkServer.Models.Board do
   """
   @spec create_changeset(board :: t(), attrs :: map() | nil) :: Ecto.Changeset.t()
   def create_changeset(board, attrs) do
-    now = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    now = NaiveDateTime.utc_now()
 
     attrs =
       attrs

--- a/lib/epochtalk_server/models/category.ex
+++ b/lib/epochtalk_server/models/category.ex
@@ -61,7 +61,7 @@ defmodule EpochtalkServer.Models.Category do
   """
   @spec create_changeset(category :: t(), attrs :: map() | nil) :: Ecto.Changeset.t()
   def create_changeset(category, attrs) do
-    now = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    now = NaiveDateTime.utc_now()
 
     attrs =
       attrs

--- a/lib/epochtalk_server/models/image_reference.ex
+++ b/lib/epochtalk_server/models/image_reference.ex
@@ -34,8 +34,8 @@ defmodule EpochtalkServer.Models.ImageReference do
     field :length, :integer
     field :type, :string
     field :checksum, :string
-    field :expiration, :naive_datetime
-    field :created_at, :naive_datetime
+    field :expiration, :naive_datetime_usec
+    field :created_at, :naive_datetime_usec
     many_to_many :posts, Post, join_through: PostImageReference
     # many_to_many :messages, Message, join_through: MessageImageReference
     many_to_many :profiles, Profile, join_through: ProfileImageReference
@@ -76,7 +76,7 @@ defmodule EpochtalkServer.Models.ImageReference do
   """
   @spec create_changeset(image_reference :: t(), attrs :: map() | nil) :: Ecto.Changeset.t()
   def create_changeset(image_reference, attrs) do
-    now = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    now = NaiveDateTime.utc_now()
     uuid = Ecto.UUID.generate()
 
     attrs =
@@ -174,7 +174,7 @@ defmodule EpochtalkServer.Models.ImageReference do
   end
 
   defp query_expired() do
-    now = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    now = NaiveDateTime.utc_now()
 
     from i in ImageReference,
       where: i.expiration < ^now and i.posts == [] and i.messages == [] and i.profiles == []

--- a/lib/epochtalk_server/models/invitation.ex
+++ b/lib/epochtalk_server/models/invitation.ex
@@ -18,7 +18,7 @@ defmodule EpochtalkServer.Models.Invitation do
   schema "invitations" do
     field :email, :string
     field :hash, :string
-    field :created_at, :naive_datetime
+    field :created_at, :naive_datetime_usec
   end
 
   ## === Changesets Functions ===
@@ -28,7 +28,7 @@ defmodule EpochtalkServer.Models.Invitation do
   """
   @spec create_changeset(invitation :: t(), attrs :: map() | nil) :: Ecto.Changeset.t()
   def create_changeset(invitation, attrs \\ %{}) do
-    now = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    now = NaiveDateTime.utc_now()
 
     attrs =
       attrs

--- a/lib/epochtalk_server/models/mention.ex
+++ b/lib/epochtalk_server/models/mention.ex
@@ -32,7 +32,7 @@ defmodule EpochtalkServer.Models.Mention do
     belongs_to :post, Post
     belongs_to :mentioner, User
     belongs_to :mentionee, User
-    field :created_at, :naive_datetime
+    field :created_at, :naive_datetime_usec
     field :viewed, :boolean, virtual: true
     field :notification_id, :integer, virtual: true
   end
@@ -44,7 +44,7 @@ defmodule EpochtalkServer.Models.Mention do
   """
   @spec create_changeset(mention :: t(), attrs :: map() | nil) :: Ecto.Changeset.t()
   def create_changeset(mention, attrs) do
-    now = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    now = NaiveDateTime.utc_now()
 
     mention =
       mention

--- a/lib/epochtalk_server/models/metadata_board.ex
+++ b/lib/epochtalk_server/models/metadata_board.ex
@@ -48,7 +48,7 @@ defmodule EpochtalkServer.Models.MetadataBoard do
     field :total_post, :integer
     field :total_thread_count, :integer
     field :last_post_username, :string
-    field :last_post_created_at, :naive_datetime
+    field :last_post_created_at, :naive_datetime_usec
     field :last_thread_id, :integer
     field :last_thread_title, :string
     field :last_post_position, :integer

--- a/lib/epochtalk_server/models/moderation_log.ex
+++ b/lib/epochtalk_server/models/moderation_log.ex
@@ -44,7 +44,7 @@ defmodule EpochtalkServer.Models.ModerationLog do
     field :action_api_url, :string
     field :action_api_method, :string
     field :action_obj, :map
-    field :action_taken_at, :naive_datetime
+    field :action_taken_at, :naive_datetime_usec
     field :action_type, :string
     field :action_display_text, :string
     field :action_display_url, :string
@@ -57,7 +57,7 @@ defmodule EpochtalkServer.Models.ModerationLog do
   """
   @spec create_changeset(moderation_log :: t(), attrs :: map() | nil) :: Ecto.Changeset.t()
   def create_changeset(moderation_log, attrs) do
-    now = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    now = NaiveDateTime.utc_now()
 
     display_data = ModerationLogHelper.get_display_data(get_in(attrs, [:action, :type]))
 

--- a/lib/epochtalk_server/models/notification.ex
+++ b/lib/epochtalk_server/models/notification.ex
@@ -29,7 +29,7 @@ defmodule EpochtalkServer.Models.Notification do
     field :data, :map
     field :viewed, :boolean
     field :type, :string
-    field :created_at, :naive_datetime
+    field :created_at, :naive_datetime_usec
   end
 
   ## === Changesets Functions ===

--- a/lib/epochtalk_server/models/poll.ex
+++ b/lib/epochtalk_server/models/poll.ex
@@ -40,7 +40,7 @@ defmodule EpochtalkServer.Models.Poll do
     field :question, :string
     field :locked, :boolean
     field :max_answers, :integer
-    field :expiration, :naive_datetime
+    field :expiration, :naive_datetime_usec
     field :change_vote, :boolean
     field :display_mode, Ecto.Enum, values: [:always, :voted, :expired]
     field :has_voted, :boolean, virtual: true

--- a/lib/epochtalk_server/models/post.ex
+++ b/lib/epochtalk_server/models/post.ex
@@ -49,9 +49,9 @@ defmodule EpochtalkServer.Models.Post do
     field :position, :integer
     field :content, :map
     field :metadata, :map
-    field :created_at, :naive_datetime
-    field :updated_at, :naive_datetime
-    field :imported_at, :naive_datetime
+    field :created_at, :naive_datetime_usec
+    field :updated_at, :naive_datetime_usec
+    field :imported_at, :naive_datetime_usec
     # field :smf_message, :map, virtual: true
   end
 
@@ -67,7 +67,7 @@ defmodule EpochtalkServer.Models.Post do
         ) :: Ecto.Changeset.t()
   # credo:disable-for-next-line
   def create_changeset(post, attrs, now_override \\ nil) do
-    now = now_override || NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    now = NaiveDateTime.utc_now()
 
     # set default values and timestamps
     post =
@@ -476,7 +476,7 @@ defmodule EpochtalkServer.Models.Post do
 
     # update updated_at field if outside of 10 min grace period,
     # or if a moderator is editing a user's post
-    now = NaiveDateTime.truncate(now, :second)
+    now = now
 
     attrs =
       if (attrs.metadata != nil && Map.keys(attrs.metadata) != []) || outside_edit_window,

--- a/lib/epochtalk_server/models/post.ex
+++ b/lib/epochtalk_server/models/post.ex
@@ -60,13 +60,8 @@ defmodule EpochtalkServer.Models.Post do
   @doc """
   Create changeset for `Post` model
   """
-  @spec create_changeset(
-          post :: t(),
-          attrs :: map() | nil,
-          now_override :: NaiveDateTime.t() | nil
-        ) :: Ecto.Changeset.t()
-  # credo:disable-for-next-line
-  def create_changeset(post, attrs, now_override \\ nil) do
+  @spec create_changeset(post :: t(), attrs :: map() | nil) :: Ecto.Changeset.t()
+  def create_changeset(post, attrs) do
     now = NaiveDateTime.utc_now()
 
     # set default values and timestamps
@@ -170,20 +165,28 @@ defmodule EpochtalkServer.Models.Post do
     Repo.transaction(fn ->
       post_cs = create_changeset(%Post{}, post_attrs)
 
-      create_post_shared(post_cs)
-    end)
-  end
+      case Repo.insert(post_cs) do
+        # changeset valid, insert success, update metadata threads and return thread
+        {:ok, db_post} ->
+          # Increment user post count
+          Profile.increment_post_count(db_post.user_id)
 
-  @doc """
-  Creates a new `Post` in the database, used during testing. Allows modification of created_at
-  """
-  @spec create_for_test(post_attrs :: map(), timestamp :: NaiveDateTime.t()) ::
-          {:ok, post :: t()} | {:error, Ecto.Changeset.t()}
-  def create_for_test(post_attrs, timestamp) do
-    Repo.transaction(fn ->
-      post_cs = create_changeset(%Post{}, post_attrs, timestamp)
+          # Set thread created_at and updated_at
+          Thread.set_timestamps(db_post.thread_id)
 
-      create_post_shared(post_cs)
+          # Set post position
+          Post.set_position_using_thread(db_post.id, db_post.thread_id)
+
+          # Increment thread post ocunt
+          Thread.increment_post_count(db_post.thread_id)
+
+          # Requery post with position and thread slug info
+          Repo.one(from p in Post, where: p.id == ^db_post.id, preload: [:thread])
+
+        # changeset error
+        {:error, cs} ->
+          Repo.rollback(cs)
+      end
     end)
   end
 
@@ -493,30 +496,5 @@ defmodule EpochtalkServer.Models.Post do
     |> Map.delete("thread_id")
     |> Map.delete("user_id")
     |> Map.delete("title")
-  end
-
-  defp create_post_shared(post_cs) do
-    case Repo.insert(post_cs) do
-      # changeset valid, insert success, update metadata threads and return thread
-      {:ok, db_post} ->
-        # Increment user post count
-        Profile.increment_post_count(db_post.user_id)
-
-        # Set thread created_at and updated_at
-        Thread.set_timestamps(db_post.thread_id)
-
-        # Set post position
-        Post.set_position_using_thread(db_post.id, db_post.thread_id)
-
-        # Increment thread post ocunt
-        Thread.increment_post_count(db_post.thread_id)
-
-        # Requery post with position and thread slug info
-        Repo.one(from p in Post, where: p.id == ^db_post.id, preload: [:thread])
-
-      # changeset error
-      {:error, cs} ->
-        Repo.rollback(cs)
-    end
   end
 end

--- a/lib/epochtalk_server/models/post.ex
+++ b/lib/epochtalk_server/models/post.ex
@@ -479,8 +479,6 @@ defmodule EpochtalkServer.Models.Post do
 
     # update updated_at field if outside of 10 min grace period,
     # or if a moderator is editing a user's post
-    now = now
-
     attrs =
       if (attrs.metadata != nil && Map.keys(attrs.metadata) != []) || outside_edit_window,
         do: Map.put(attrs, :updated_at, now),

--- a/lib/epochtalk_server/models/post_draft.ex
+++ b/lib/epochtalk_server/models/post_draft.ex
@@ -25,7 +25,7 @@ defmodule EpochtalkServer.Models.PostDraft do
   schema "user_drafts" do
     belongs_to :user, User
     field :draft, :string
-    field :updated_at, :naive_datetime
+    field :updated_at, :naive_datetime_usec
   end
 
   ## === Changeset Functions ===
@@ -35,7 +35,7 @@ defmodule EpochtalkServer.Models.PostDraft do
   """
   @spec upsert_changeset(draft :: PostDraft.t(), attrs :: map() | nil) :: Ecto.Changeset.t()
   def upsert_changeset(draft, attrs \\ %{}) do
-    updated_at = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    updated_at = NaiveDateTime.utc_now()
 
     draft =
       draft

--- a/lib/epochtalk_server/models/profile.ex
+++ b/lib/epochtalk_server/models/profile.ex
@@ -29,7 +29,7 @@ defmodule EpochtalkServer.Models.Profile do
     field :raw_signature, :string
     field :post_count, :integer, default: 0
     field :fields, :map
-    field :last_active, :naive_datetime
+    field :last_active, :naive_datetime_usec
   end
 
   ## === Changesets Functions ===
@@ -117,13 +117,13 @@ defmodule EpochtalkServer.Models.Profile do
     from(p in Profile, where: p.user_id == ^user_id)
     |> Repo.update_all(
       set: [
-        last_active: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+        last_active: NaiveDateTime.utc_now()
       ]
     )
   end
 
   defp update_if_more_than_one_minute_has_passed(user_id, last_active) do
-    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    now = NaiveDateTime.utc_now()
     last_active_plus_one_minute = NaiveDateTime.add(last_active, 1, :minute)
 
     at_least_one_minute_has_passed =

--- a/lib/epochtalk_server/models/role.ex
+++ b/lib/epochtalk_server/models/role.ex
@@ -49,8 +49,8 @@ defmodule EpochtalkServer.Models.Role do
     field :permissions, :map
     field :priority_restrictions, {:array, :integer}
 
-    field :created_at, :naive_datetime
-    field :updated_at, :naive_datetime
+    field :created_at, :naive_datetime_usec
+    field :updated_at, :naive_datetime_usec
   end
 
   ## === Changesets Functions ===
@@ -71,7 +71,7 @@ defmodule EpochtalkServer.Models.Role do
   """
   @spec update_changeset(role :: Role.t(), attrs :: map() | nil) :: Ecto.Changeset.t()
   def update_changeset(role, attrs \\ %{}) do
-    updated_at = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    updated_at = NaiveDateTime.utc_now()
 
     role =
       role

--- a/lib/epochtalk_server/models/thread.ex
+++ b/lib/epochtalk_server/models/thread.ex
@@ -90,12 +90,8 @@ defmodule EpochtalkServer.Models.Thread do
   @doc """
   Create changeset for creation of `Thread` model
   """
-  @spec create_changeset(
-          thread :: t(),
-          attrs :: map() | nil,
-          now_override :: NaiveDateTime.t() | nil
-        ) :: Ecto.Changeset.t()
-  def create_changeset(thread, attrs, now_override \\ nil) do
+  @spec create_changeset(thread :: t(), attrs :: map() | nil) :: Ecto.Changeset.t()
+  def create_changeset(thread, attrs) do
     now = NaiveDateTime.utc_now()
 
     # set default values and timestamps
@@ -129,9 +125,9 @@ defmodule EpochtalkServer.Models.Thread do
   @doc """
   Creates a new `Thread` in the database
   """
-  @spec create(thread_attrs :: map(), user :: map(), timestamp :: NaiveDateTime.t() | nil) ::
+  @spec create(thread_attrs :: map(), user :: map()) ::
           {:ok, thread :: t()} | {:error, Ecto.Changeset.t()}
-  def create(thread_attrs, user, timestamp \\ nil) do
+  def create(thread_attrs, user) do
     thread_cs = create_changeset(%Thread{}, thread_attrs)
 
     case Repo.transaction(fn ->
@@ -147,7 +143,7 @@ defmodule EpochtalkServer.Models.Thread do
            # create poll, if necessary
            db_poll = handle_create_poll(db_thread.id, thread_attrs["poll"], user)
            # create post
-           db_post = handle_create_post(db_thread.id, thread_attrs, user, timestamp)
+           db_post = handle_create_post(db_thread.id, thread_attrs, user)
            # return post (preloaded thread) and poll data
            %{post: db_post, poll: db_poll}
          end) do
@@ -894,7 +890,7 @@ defmodule EpochtalkServer.Models.Thread do
     end
   end
 
-  defp handle_create_post(thread_id, thread_attrs, user, timestamp) do
+  defp handle_create_post(thread_id, thread_attrs, user) do
     post_attrs = %{
       thread_id: thread_id,
       user_id: user.id,
@@ -905,12 +901,7 @@ defmodule EpochtalkServer.Models.Thread do
       }
     }
 
-    if is_nil(timestamp) do
-      Post.create(post_attrs)
-    else
-      Post.create_for_test(post_attrs, timestamp)
-    end
-    |> case do
+    case Post.create(post_attrs) do
       {:ok, post} -> post
       {:error, cs} -> Repo.rollback(cs)
     end

--- a/lib/epochtalk_server/models/thread.ex
+++ b/lib/epochtalk_server/models/thread.ex
@@ -52,9 +52,9 @@ defmodule EpochtalkServer.Models.Thread do
     field :slug, :string
     field :moderated, :boolean
     field :post_count, :integer
-    field :created_at, :naive_datetime
-    field :imported_at, :naive_datetime
-    field :updated_at, :naive_datetime
+    field :created_at, :naive_datetime_usec
+    field :imported_at, :naive_datetime_usec
+    field :updated_at, :naive_datetime_usec
     has_many :posts, Post
     field :poster_ids, {:array, :integer}, virtual: true
     field :user_id, :integer, virtual: true
@@ -96,7 +96,7 @@ defmodule EpochtalkServer.Models.Thread do
           now_override :: NaiveDateTime.t() | nil
         ) :: Ecto.Changeset.t()
   def create_changeset(thread, attrs, now_override \\ nil) do
-    now = now_override || NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    now = NaiveDateTime.utc_now()
 
     # set default values and timestamps
     thread =

--- a/lib/epochtalk_server/models/trust_feedback.ex
+++ b/lib/epochtalk_server/models/trust_feedback.ex
@@ -39,7 +39,7 @@ defmodule EpochtalkServer.Models.TrustFeedback do
     field :scammer, :boolean
     field :reference, :string
     field :comments, :string
-    field :created_at, :naive_datetime
+    field :created_at, :naive_datetime_usec
   end
 
   ## === Changesets Functions ===

--- a/lib/epochtalk_server/models/user.ex
+++ b/lib/epochtalk_server/models/user.ex
@@ -61,9 +61,9 @@ defmodule EpochtalkServer.Models.User do
     field :confirmation_token, :string
     field :reset_token, :string
     field :reset_expiration, :string
-    field :created_at, :naive_datetime
-    field :imported_at, :naive_datetime
-    field :updated_at, :naive_datetime
+    field :created_at, :naive_datetime_usec
+    field :imported_at, :naive_datetime_usec
+    field :updated_at, :naive_datetime_usec
     field :deleted, :boolean, default: false
     field :malicious_score, :decimal
     field :smf_member, :map, virtual: true
@@ -84,7 +84,7 @@ defmodule EpochtalkServer.Models.User do
   """
   @spec registration_changeset(user :: t(), attrs :: map() | nil) :: Ecto.Changeset.t()
   def registration_changeset(user, attrs) do
-    now = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    now = NaiveDateTime.utc_now()
 
     # set timestamps
     user =

--- a/lib/epochtalk_server/models/user_activity.ex
+++ b/lib/epochtalk_server/models/user_activity.ex
@@ -37,8 +37,8 @@ defmodule EpochtalkServer.Models.UserActivity do
   @primary_key false
   schema "user_activity" do
     belongs_to :user, User
-    field :current_period_start, :naive_datetime
-    field :current_period_offset, :naive_datetime
+    field :current_period_start, :naive_datetime_usec
+    field :current_period_offset, :naive_datetime_usec
     field :remaining_period_activity, :integer, default: 14
     field :total_activity, :integer, default: 0
   end
@@ -114,7 +114,7 @@ defmodule EpochtalkServer.Models.UserActivity do
 
     period_start_unix = to_unix(info.current_period_start)
     period_end_naive = from_unix(period_start_unix + @period_length_ms)
-    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    now = NaiveDateTime.utc_now()
 
     # update info if period has ended
     period_ended = NaiveDateTime.compare(now, period_end_naive) == :gt

--- a/lib/epochtalk_server/models/user_ignored.ex
+++ b/lib/epochtalk_server/models/user_ignored.ex
@@ -25,7 +25,7 @@ defmodule EpochtalkServer.Models.UserIgnored do
   schema "ignored" do
     belongs_to :user, User
     belongs_to :ignored_user, User
-    field :created_at, :naive_datetime
+    field :created_at, :naive_datetime_usec
   end
 
   ## === Database Functions ===

--- a/lib/epochtalk_server/models/user_ip.ex
+++ b/lib/epochtalk_server/models/user_ip.ex
@@ -23,7 +23,7 @@ defmodule EpochtalkServer.Models.UserIp do
   schema "ips" do
     belongs_to :user, User
     field :user_ip, :string
-    field :created_at, :naive_datetime
+    field :created_at, :naive_datetime_usec
   end
 
   ## === Database Functions ===
@@ -40,7 +40,7 @@ defmodule EpochtalkServer.Models.UserIp do
       %UserIp{
         user_id: user_id,
         user_ip: user_ip,
-        created_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+        created_at: NaiveDateTime.utc_now()
       },
       on_conflict: :nothing,
       conflict_target: [:user_id, :user_ip]

--- a/lib/epochtalk_server/models/user_thread_view.ex
+++ b/lib/epochtalk_server/models/user_thread_view.ex
@@ -24,7 +24,7 @@ defmodule EpochtalkServer.Models.UserThreadView do
   schema "thread_views" do
     belongs_to :user, User
     belongs_to :thread, Thread
-    field :time, :naive_datetime
+    field :time, :naive_datetime_usec
   end
 
   ## === Database Functions ===
@@ -36,7 +36,7 @@ defmodule EpochtalkServer.Models.UserThreadView do
   @spec upsert(user_id :: non_neg_integer, thread_id :: non_neg_integer) ::
           {:ok, t()} | {:error, Ecto.Changeset.t()}
   def upsert(user_id, thread_id) when is_integer(user_id) and is_integer(thread_id) do
-    now = NaiveDateTime.truncate(NaiveDateTime.utc_now(), :second)
+    now = NaiveDateTime.utc_now()
 
     Repo.insert(
       %UserThreadView{user_id: user_id, thread_id: thread_id, time: now},

--- a/lib/epochtalk_server_web/json/poll_json.ex
+++ b/lib/epochtalk_server_web/json/poll_json.ex
@@ -49,7 +49,7 @@ defmodule EpochtalkServerWeb.Controllers.PollJSON do
       )
 
     # hide votes if poll is not expired and display mode is set to display votes when expired
-    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    now = NaiveDateTime.utc_now()
 
     hide_votes =
       (poll.display_mode === :voted && !has_voted) ||

--- a/priv/repo/seed_roles.exs
+++ b/priv/repo/seed_roles.exs
@@ -9,8 +9,8 @@ roles = [
     priority: 0,
     highlight_color: "#FF7442",
     permissions: %{},
-    created_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
-    updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    created_at: NaiveDateTime.utc_now(),
+    updated_at: NaiveDateTime.utc_now()
   },
   %{
     id: 2,
@@ -20,8 +20,8 @@ roles = [
     priority: 1,
     highlight_color: "#FF4C4C",
     permissions: %{},
-    created_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
-    updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    created_at: NaiveDateTime.utc_now(),
+    updated_at: NaiveDateTime.utc_now()
   },
   %{
     id: 3,
@@ -31,8 +31,8 @@ roles = [
     priority: 2,
     highlight_color: "#32A56E",
     permissions: %{},
-    created_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
-    updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    created_at: NaiveDateTime.utc_now(),
+    updated_at: NaiveDateTime.utc_now()
   },
   %{
     id: 4,
@@ -42,8 +42,8 @@ roles = [
     priority: 3,
     highlight_color: "#508DD0",
     permissions: %{},
-    created_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
-    updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    created_at: NaiveDateTime.utc_now(),
+    updated_at: NaiveDateTime.utc_now()
   },
   %{
     id: 5,
@@ -52,8 +52,8 @@ roles = [
     description: "Standard account with access to create threads and post",
     priority: 4,
     permissions: %{},
-    created_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
-    updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    created_at: NaiveDateTime.utc_now(),
+    updated_at: NaiveDateTime.utc_now()
   },
   %{
     id: 6,
@@ -62,8 +62,8 @@ roles = [
     description: "Moderates Newbies only, otherwise mirrors User role unless modified",
     priority: 5,
     permissions: %{},
-    created_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
-    updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    created_at: NaiveDateTime.utc_now(),
+    updated_at: NaiveDateTime.utc_now()
   },
   %{
     id: 7,
@@ -72,8 +72,8 @@ roles = [
     description: "Brand new users",
     priority: 6,
     permissions: %{},
-    created_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
-    updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    created_at: NaiveDateTime.utc_now(),
+    updated_at: NaiveDateTime.utc_now()
   },
   %{
     id: 8,
@@ -83,8 +83,8 @@ roles = [
     priority: 7,
     priority_restrictions: [0, 1, 2, 3],
     permissions: %{},
-    created_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
-    updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    created_at: NaiveDateTime.utc_now(),
+    updated_at: NaiveDateTime.utc_now()
   },
   %{
     id: 9,
@@ -93,8 +93,8 @@ roles = [
     description: "Read only access",
     priority: 8,
     permissions: %{},
-    created_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
-    updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    created_at: NaiveDateTime.utc_now(),
+    updated_at: NaiveDateTime.utc_now()
   },
   %{
     id: 10,
@@ -103,8 +103,8 @@ roles = [
     description: "Role assigned to unauthorized users when public forum is disabled",
     priority: 9,
     permissions: %{},
-    created_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second),
-    updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    created_at: NaiveDateTime.utc_now(),
+    updated_at: NaiveDateTime.utc_now()
   }
 ]
 

--- a/test/epochtalk_server/session_test.exs
+++ b/test/epochtalk_server/session_test.exs
@@ -9,7 +9,7 @@ defmodule Test.EpochtalkServer.Session do
   @almost_one_day_in_seconds @one_day_in_seconds - 100
   @four_weeks_in_seconds 4 * 7 * @one_day_in_seconds
   @almost_four_weeks_in_seconds @four_weeks_in_seconds - 100
-  @max_date "9999-12-31 00:00:00"
+  @max_date "9999-12-31 00:00:00.000000"
   alias EpochtalkServer.Session
   alias EpochtalkServer.Models.Profile
   alias EpochtalkServer.Models.User

--- a/test/epochtalk_server_web/controllers/poll_test.exs
+++ b/test/epochtalk_server_web/controllers/poll_test.exs
@@ -771,8 +771,7 @@ defmodule Test.EpochtalkServerWeb.Controllers.Poll do
     } do
       expiration = NaiveDateTime.utc_now() |> NaiveDateTime.add(10)
 
-      expiration_string =
-        NaiveDateTime.to_iso8601(expiration) |> String.split(".") |> List.first()
+      expiration_string = NaiveDateTime.to_iso8601(expiration)
 
       Poll.update(%{"thread_id" => thread_id, "expiration" => expiration})
 
@@ -958,8 +957,7 @@ defmodule Test.EpochtalkServerWeb.Controllers.Poll do
     } do
       expiration = NaiveDateTime.utc_now() |> NaiveDateTime.add(10)
 
-      expiration_string =
-        NaiveDateTime.to_iso8601(expiration) |> String.split(".") |> List.first()
+      expiration_string = NaiveDateTime.to_iso8601(expiration)
 
       Poll.update(%{"thread_id" => thread_id, "expiration" => expiration})
 

--- a/test/epochtalk_server_web/controllers/thread_test.exs
+++ b/test/epochtalk_server_web/controllers/thread_test.exs
@@ -959,7 +959,9 @@ defmodule Test.EpochtalkServerWeb.Controllers.Thread do
 
       # create posts in move board thread
       # and get last post for comparison
-      move_board_factory_posts = build_list(2, :post, user: mod_user, thread: move_board_thread.post.thread)
+      move_board_factory_posts =
+        build_list(2, :post, user: mod_user, thread: move_board_thread.post.thread)
+
       [_, {:ok, new_board_last_post}] = move_board_factory_posts
 
       # create a post on old board that's newer than last post on old board

--- a/test/epochtalk_server_web/controllers/user_test.exs
+++ b/test/epochtalk_server_web/controllers/user_test.exs
@@ -94,8 +94,8 @@ defmodule Test.EpochtalkServerWeb.Controllers.User do
 
       {:ok, registered_user} = User.by_username(register_attrs.username)
       assert response["id"] == registered_user.id
-      assert registered_user.created_at == mocked_date |> NaiveDateTime.truncate(:second)
-      assert registered_user.updated_at == mocked_date |> NaiveDateTime.truncate(:second)
+      assert registered_user.created_at == mocked_date
+      assert registered_user.updated_at == mocked_date
     end
 
     test "when email is already taken, errors", %{

--- a/test/support/factories/post.ex
+++ b/test/support/factories/post.ex
@@ -20,10 +20,7 @@ defmodule Test.Support.Factories.Post do
       def post_factory(%{user: user, thread: thread} = attrs) do
         attributes = build(:post_attributes, attrs)
 
-        timestamp =
-          sequence(:post_timestamp, &NaiveDateTime.add(~N[1970-01-01 00:00:00], &1 * 60 * 60))
-
-        Post.create_for_test(attributes, timestamp)
+        Post.create(attributes)
       end
     end
   end

--- a/test/support/factories/thread.ex
+++ b/test/support/factories/thread.ex
@@ -23,10 +23,7 @@ defmodule Test.Support.Factories.Thread do
       def thread_factory(%{board: board, user: user} = attrs) do
         attributes = build(:thread_attributes, attrs)
 
-        timestamp =
-          sequence(:post_timestamp, &NaiveDateTime.add(~N[1970-01-01 00:00:00], &1 * 60 * 60))
-
-        Thread.create(attributes, user, timestamp)
+        Thread.create(attributes, user)
         |> case do
           {:ok, thread} ->
             thread_id = thread.post.thread.id


### PR DESCRIPTION
refactor to improve test handling

changes naivedatetime's at `second` precision to `usec`

reverts changes to models and factories that add functionality for specifying `created_at` time.
adapting `usec` usage eliminates the need to sequence thread/post creation

moves data creation for `thread move` test into the test itself, simplifying `setup()` and reducing
complexity that could lead to issues when writing future tests